### PR TITLE
Improve padding setting for Input component

### DIFF
--- a/src/Input.ts
+++ b/src/Input.ts
@@ -337,6 +337,12 @@ export class Input extends Container
         return this.inputField.text;
     }
 
+    /**
+     * Sets paddings
+     * @param value - number or array of numbers number - same val for all the sides.
+     * or : [top, right, bottom, left]
+     * or: [top&bottom, right&left]
+     */
     set padding(value: Padding)
     {
         if (typeof value === 'number')
@@ -354,10 +360,9 @@ export class Input extends Container
             this.paddingBottom = value[2] ?? value[0] ?? 0;
             this.paddingLeft = value[3] ?? value[1] ?? value[0] ?? 0;
         }
-
-        console.log({ value, t: this.paddingTop, r: this.paddingRight, b: this.paddingBottom, l: this.paddingLeft });
     }
 
+    // Return array of paddings [top, right, bottom, left]
     get padding(): [number, number, number, number]
     {
         return [this.paddingTop, this.paddingRight, this.paddingBottom, this.paddingLeft];

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -6,7 +6,16 @@ import { TextStyle, Text } from '@pixi/text';
 import { Signal } from 'typed-signals';
 import { getView } from './utils/helpers/view';
 
-export type Padding = number | [number, number] | [number, number, number, number];
+export type Padding =
+  | number
+  | [number, number]
+  | [number, number, number, number]
+  | {
+      left?: number;
+      right?: number;
+      top?: number;
+      bottom?: number;
+  };
 
 export type InputOptions = {
     bg?: Container | string;
@@ -24,7 +33,13 @@ export type InputOptions = {
  * ```
  * new Input({
  *     bg: Sprite.from('input.png'),
- *     placeholder: 'Enter text'
+ *     placeholder: 'Enter text',
+ *     padding: {
+ *      top: 11,
+ *      right: 11,
+ *      bottom: 11,
+ *      left: 11
+ *     } // alternatively you can use [11, 11, 11, 11] or [11, 11] or just 11
  * });
  * ```
  */
@@ -338,12 +353,18 @@ export class Input extends Container
     }
 
     /**
-     * Sets paddings
-     * @param value - number or array of numbers number - same val for all the sides.
-     * or : [top, right, bottom, left]
+     * Set paddings
+     * @param value - number, array of 4 numbers or object with keys: top, right, bottom, left
+     * or: [top, right, bottom, left]
      * or: [top&bottom, right&left]
+     * or: {
+     *  left: 10,
+     *  right: 10,
+     *  top: 10,
+     *  bottom: 10,
+     * }
      */
-    set padding(value: Padding)
+    public set padding(value: Padding)
     {
         if (typeof value === 'number')
         {
@@ -360,10 +381,17 @@ export class Input extends Container
             this.paddingBottom = value[2] ?? value[0] ?? 0;
             this.paddingLeft = value[3] ?? value[1] ?? value[0] ?? 0;
         }
+        else if (typeof value === 'object')
+        {
+            this.paddingTop = value.top ?? 0;
+            this.paddingRight = value.right ?? 0;
+            this.paddingBottom = value.bottom ?? 0;
+            this.paddingLeft = value.left ?? 0;
+        }
     }
 
     // Return array of paddings [top, right, bottom, left]
-    get padding(): [number, number, number, number]
+    public get padding(): [number, number, number, number]
     {
         return [this.paddingTop, this.paddingRight, this.paddingBottom, this.paddingLeft];
     }

--- a/src/stories/input/InputGraphics.stories.ts
+++ b/src/stories/input/InputGraphics.stories.ts
@@ -70,7 +70,7 @@ export const UseGraphics = ({
             align,
             placeholder,
             value: text,
-            padding: [verticalPadding + (border ? border + 3 : 0), horizontalPadding + border ? border + 3 : 0]
+            padding: [verticalPadding + (border ? border + 3 : 0), horizontalPadding + (border ? border + 3 : 0)]
         });
 
         input.onChange.connect(() => onChange(input.value));

--- a/src/stories/input/InputGraphics.stories.ts
+++ b/src/stories/input/InputGraphics.stories.ts
@@ -70,7 +70,7 @@ export const UseGraphics = ({
             align,
             placeholder,
             value: text,
-            padding: [verticalPadding + (border ? border + 3 : 0), horizontalPadding + (border ? border + 3 : 0)]
+            padding: [verticalPadding + (border ? border + 3 : 0), horizontalPadding + border ? border + 3 : 0]
         });
 
         input.onChange.connect(() => onChange(input.value));

--- a/src/stories/input/InputGraphics.stories.ts
+++ b/src/stories/input/InputGraphics.stories.ts
@@ -21,6 +21,8 @@ const args = {
     height: 70,
     radius: 11,
     amount: 1,
+    horizontalPadding: 11,
+    verticalPadding: 11,
 
     onChange: action('Input: ')
 };
@@ -39,6 +41,8 @@ export const UseGraphics = ({
     maxLength,
     align,
     placeholder,
+    horizontalPadding,
+    verticalPadding,
     onChange
 }: any) =>
 {
@@ -57,7 +61,6 @@ export const UseGraphics = ({
                 .drawRoundedRect(0, 0, width, height, radius + border)
                 .beginFill(backgroundColor)
                 .drawRoundedRect(border, border, width - (border * 2), height - (border * 2), radius),
-            padding: border ? border + 3 : 0,
             textStyle: {
                 ...defaultTextStyle,
                 fill: textColor,
@@ -66,7 +69,8 @@ export const UseGraphics = ({
             maxLength,
             align,
             placeholder,
-            value: text
+            value: text,
+            padding: [verticalPadding + (border ? border + 3 : 0), horizontalPadding + (border ? border + 3 : 0)]
         });
 
         input.onChange.connect(() => onChange(input.value));

--- a/src/stories/input/InputSprite.stories.ts
+++ b/src/stories/input/InputSprite.stories.ts
@@ -14,12 +14,28 @@ const args = {
     textColor: '#000000',
     maxLength: 100,
     fontSize: 24,
-    padding: 5,
+    paddingTop: 11,
+    paddingRight: 11,
+    paddingBottom: 11,
+    paddingLeft: 11,
     amount: 1,
     onChange: action('Input: ')
 };
 
-export const UseSprite = ({ text, amount, padding, textColor, fontSize, maxLength, align, placeholder, onChange }: any) =>
+export const UseSprite = ({
+    text,
+    amount,
+    paddingTop,
+    paddingRight,
+    paddingBottom,
+    paddingLeft,
+    textColor,
+    fontSize,
+    maxLength,
+    align,
+    placeholder,
+    onChange
+}: any) =>
 {
     const view = new Layout({ type: 'vertical', elementsMargin: 10 });
 
@@ -32,7 +48,7 @@ export const UseSprite = ({ text, amount, padding, textColor, fontSize, maxLengt
             // Component usage
             const input = new Input({
                 bg: Sprite.from('input.png'),
-                padding,
+                padding: [paddingTop, paddingRight, paddingBottom, paddingLeft],
                 textStyle: {
                     ...defaultTextStyle,
                     fill: textColor,


### PR DESCRIPTION
Closes #32

Now you can set padding same as css properties:
```
padding: 10 
// 10px for all 4 sides
```
This way we are saving backwards compatibility with the previous version

```
padding: [10, 20] 
// 10px top and bottom sides
// 20px for left and right sides
```
```
padding: [10, 20, 30, 40] 
// 10px top the side,
// 20px for the right side
// 30px for the bottom side
// 40px for the left side
```
### Example form the docs:
```
new Input({
      bg: Sprite.from('input.png'),
      placeholder: 'Enter text',
      padding: {
       top: 11,
       right: 11,
       bottom: 11,
       left: 11
      } // alternatively you can use [11, 11, 11, 11] or [11, 11] or just 11
 })
```

Stories also updated to test this edge cases.