### PR TITLE
Fix docs examples styling

### DIFF
--- a/src/Button.ts
+++ b/src/Button.ts
@@ -8,7 +8,6 @@ import { Signal } from 'typed-signals';
  *
  * so you can subscribe to them and use your container-based instance as a button.
  * @example
- * ```
  * const container = new Container();
  * const button = new Button(
  *      new Graphics()
@@ -19,7 +18,6 @@ import { Signal } from 'typed-signals';
  * buttonEvents.onPress.connect(() => console.log('onPress'));
  *
  * container.addChild(buttonEvents.view);
- * ```
  */
 export class Button
 {

--- a/src/CheckBox.ts
+++ b/src/CheckBox.ts
@@ -19,15 +19,12 @@ export type CheckBoxOptions = {
 /**
  * Creates a container-based checkbox element.
  * @example
- * ```
  *  new CheckBox({
  *     style: {
  *         unchecked: `switch_off.png`,
  *         checked: `switch_on.png`,
  *     }
  * });
- *
- * ```
  */
 export class CheckBox extends Switcher
 {

--- a/src/DoubleSlider.ts
+++ b/src/DoubleSlider.ts
@@ -6,7 +6,6 @@ import { Signal } from 'typed-signals';
 /**
  * Creates a slider with range selection option.
  * @example
- * ```
  * const doubleSlider = new DoubleSlider({
  *      bg: 'slider_bg.png',
  *      fill: 'slider_progress.png',
@@ -17,7 +16,6 @@ import { Signal } from 'typed-signals';
  * doubleSlider.onChange.connect((value1, value2) =>
  *     console.log(`New slider range ${value1} - ${value2}`)
  * );
- * ```
  */
 
 export class DoubleSlider extends SliderBase

--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -61,7 +61,6 @@ export type ButtonOptions = Views & {
  * If views are not the same size, offset property of the constructor
  * can be used to adjust the position of the text, icon and the views.
  * @example
- * ```
  * const button = new FancyButton({
  *     defaultView: `button.png`,
  *     hoverView: `button_hover.png`,
@@ -121,7 +120,6 @@ export type ButtonOptions = Views & {
  * });
  *
  * button.onPress.connect(() => console.log('Button pressed!'));
- * ```
  */
 export class FancyButton extends Container
 {

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -30,7 +30,6 @@ export type InputOptions = {
 /**
  * Container-based component that creates an input to read the user's text.
  * @example
- * ```
  * new Input({
  *     bg: Sprite.from('input.png'),
  *     placeholder: 'Enter text',
@@ -41,7 +40,6 @@ export type InputOptions = {
  *      left: 11
  *     } // alternatively you can use [11, 11, 11, 11] or [11, 11] or just 11
  * });
- * ```
  */
 export class Input extends Container
 {

--- a/src/Layout.ts
+++ b/src/Layout.ts
@@ -14,7 +14,6 @@ export type LayoutOptions = {
  *
  * It is used inside elements with repeatable content, like {@link Select} or {@link ScrollBox}.
  * @example
- * ```
  * const layout = new Layout({
  *    children: [
         new Graphics().beginFill(0x000000).drawRect(0, 0, 50, 50),
@@ -23,7 +22,6 @@ export type LayoutOptions = {
  * });
  *
  * layout.addChild(new Graphics().beginFill(0x000000).drawRect(0, 0, 50, 50));
- * ```
  */
 export class Layout extends Container
 {

--- a/src/MaskedFrame.ts
+++ b/src/MaskedFrame.ts
@@ -14,14 +14,12 @@ export type MaskedFrameOptions = {
 /**
  * Draws a border or apply a mask of any shape to a container.
  * @example
- * ```
  * new MaskedFrame({
  *     target: `avatar.png`,
  *     mask: `avatar_mask.png`,
  *     borderWidth: 5,
  *     borderColor: 0xFFFFFF,
  * });
- * ```
  */
 export class MaskedFrame extends Graphics
 {

--- a/src/ProgressBar.ts
+++ b/src/ProgressBar.ts
@@ -15,13 +15,11 @@ export type ProgressBarOptions = {
 /**
  * Creates a ProgressBar.
  * @example
- * ```
  * new ProgressBar({
  *     bg: 'slider_bg.png',
  *     fill: 'slider.png',
  *     progress: 50,
  * });
- * ```
  */
 export class ProgressBar extends Container
 {

--- a/src/RadioGroup.ts
+++ b/src/RadioGroup.ts
@@ -34,7 +34,6 @@ export type RadioBoxOptions = {
  *
  * Only one checkbox can be selected at a time.
  * @example
- * ```
  * new RadioGroup({
  *     selectedItem: 0,
  *     items: ['Option 1', 'Option 2', 'Option 3'],
@@ -43,8 +42,6 @@ export type RadioBoxOptions = {
  *         checked: 'radio_checked.png'
  *     },
  * });
- *
- * ```
  */
 export class RadioGroup extends Container
 {

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -28,7 +28,6 @@ export type ScrollBoxOptions = {
  *
  * Items, that are out of the visible area, are not rendered.
  * @example
- * ```
  * new ScrollBox({
  *     background: 0XFFFFFF,
  *     items: [
@@ -41,7 +40,6 @@ export type ScrollBoxOptions = {
  *         new Graphics().beginFill(0x000000).drawRect(0, 0, 200, 50),
  *     ],
  * });
- * ```
  */
 
 export class ScrollBox extends Container

--- a/src/Select.ts
+++ b/src/Select.ts
@@ -49,7 +49,6 @@ export type SelectOptions = {
  *
  * It is a composition of a {@link Button} and a {@link ScrollBox}.
  * @example
- * ```
  * new Select({
  *     closedBG: `select_closed.png`,
  *     openBG: `select_open.png`,
@@ -67,8 +66,6 @@ export type SelectOptions = {
  *         radius: 30,
  *     },
  * });
- *
- * ```
  */
 
 // TODO: rewrite this basing on Swich

--- a/src/Slider.ts
+++ b/src/Slider.ts
@@ -28,7 +28,6 @@ export type SliderOptions = {
 /**
  * Creates a slider to select a single value.
  * @example
- * ```
  * new Slider({
  *     bg: 'slider_bg.png',
  *     fill: 'slider.png',
@@ -41,7 +40,6 @@ export type SliderOptions = {
  * singleSlider.onChange.connect((value) => {
  *     console.log(`Slider changed to ${value}`);
  * });
- * ```
  */
 export class Slider extends SliderBase
 {

--- a/src/Switcher.ts
+++ b/src/Switcher.ts
@@ -11,7 +11,6 @@ import { ButtonEvent } from './utils/HelpTypes';
  *
  * Can be used for creating tabs, radio buttons, checkboxes etc.
  * @example
- * ```
  * // switch on click
  * const switch = new Swich([`switch_off.png`, `switch_on.png`]);
  *
@@ -19,8 +18,6 @@ import { ButtonEvent } from './utils/HelpTypes';
  * const button = new Swich([`button_default.png`, `button_hover.png`], ['onHover', 'onOut']);
  *
  * button.events.onPress.connect(() => console.log('button pressed'));
- *
- * ```
  */
 export class Switcher extends Container
 {


### PR DESCRIPTION
There was an issue with examples styling that is fixed with this PR.
It removes "```" from the top and bottom of all examples

<img width="1017" alt="Screenshot 2023-02-21 at 18 24 06" src="https://user-images.githubusercontent.com/11766115/220402030-ce10303e-1798-494c-abac-bcd0bcf93606.png">
