### PR TITLE
Fix scroll direction problem when game rotated.

### DIFF
--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -307,7 +307,9 @@ export class ScrollBox extends Container
         this.on('pointerdown', (e: FederatedPointerEvent) =>
         {
             this.isDragging = 1;
-            this._trackpad.pointerDown(e.global);
+            const touchPoint = this.worldTransform.applyInverse(e.global);
+
+            this._trackpad.pointerDown(touchPoint);
         });
 
         this.on('pointerup', () =>
@@ -326,7 +328,9 @@ export class ScrollBox extends Container
 
         this.on('globalpointermove', (e: FederatedPointerEvent) =>
         {
-            this._trackpad.pointerMove(e.global);
+            const touchPoint = this.worldTransform.applyInverse(e.global);
+
+            this._trackpad.pointerMove(touchPoint);
 
             if (!this.isDragging) return;
 

--- a/src/utils/trackpad/Trackpad.ts
+++ b/src/utils/trackpad/Trackpad.ts
@@ -45,6 +45,7 @@ export class Trackpad
 
     pointerDown(pos: Point): void
     {
+        this._globalPosition = pos;
         this.xAxis.grab(pos.x);
         this.yAxis.grab(pos.y);
         this._isDown = true;


### PR DESCRIPTION
It's usual to rotate the whole game scene, when user's mobile device change orientation.

In order to adjust this situation, ScrollBox should use the touch point after `worldTransform.applyInverse`.

And then, because Trackpad is using shared instance `e.global` before, however after modifying the `_globalPosition` won't update automatically by the "shared global position" feature. It will cause list position jitter when user scroll and release and touch down again (just touch down, no move).

So Trackpad should update `_globalPosition` in the `pointerDown` method manually.