### PR TITLE
fix: missing export for CircularProgressBar

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './Button';
 export * from './CheckBox';
+export * from './CircularProgressBar';
 export * from './DoubleSlider';
 export * from './FancyButton';
 export * from './Input';


### PR DESCRIPTION
heya

CircularProgressBar should be exported, doesn't it?