### PR TITLE
115 [v.0.9.1] FancyButton: tweedle.js reports a WARNING on each playAnimations if both "animations" and any of "defaultView", "hoverView", "pressedView" or "icon" properties are set in constructor.

### DIFF
--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -191,14 +191,14 @@ export class FancyButton extends ButtonContainer
             Ticker.shared.add(() => Group.shared.update());
         }
 
+        this.setState('default');
+
         this.defaultView = defaultView;
         this.hoverView = hoverView;
         this.pressedView = pressedView;
         this.disabledView = disabledView;
         this.text = text;
         this.iconView = icon;
-
-        this.setState('default');
 
         this.initStateControl();
     }


### PR DESCRIPTION
https://github.com/pixijs/ui/issues/115
