### PR TITLE
Feat: Allow Custom Text Class and Sprites for Items

### DIFF
--- a/src/Select.ts
+++ b/src/Select.ts
@@ -54,7 +54,29 @@ type TextSelectOptions = {
     /** Specify which type of content is being used in the dropdown */
     type: 'text';
     /** Override the text class to use, otherwise it will use the default Pixi Text */
-    textClass?: (...args: any[]) => any;
+    textClass?: new (...args: any[]) => any;
+    /**
+     * Custom options to be passed to the custom text class which will be
+     * in form of an array of arguments and will append after the text string when instantiating.
+     * If it's a single option object, please also wrap it in an array.
+     *
+     * eg:
+     * - [arg1, arg2, arg3] => new TextClass(text, arg1, arg2, arg3)
+     * - [{ arg1, arg2, arg3 }] => new TextClass(text, { arg1, arg2, arg3 })
+     *
+     * If not provided, it will use the specified text style if also supplied.
+     */
+    textArgs?: any;
+    /**
+     * This is explicity for custom text classes that expect text string to be supplied
+     * within a single options object. The text string will be added to the object with the
+     * key specified here.
+     *
+     * eg:
+     * { `consolidateOptionsWithKey`: 'label', textArgs: [{ arg1, arg2, arg3 }] }
+     * => new TextClass({ arg1, arg2, arg3, label: text })
+     */
+    consolidateOptionsWithKey?: string;
     /** Specify the text style options */
     textStyle?: Partial<TextStyle>;
     textUpdate?: (view: any, text: string) => void;
@@ -357,9 +379,21 @@ export class Select extends Container
         if (this.options.type === 'text')
         {
             const TextClass = this.options.textClass ?? Text;
-            const text = new TextClass(item, this.options.textStyle);
+            const style = this.options.textStyle;
+            const args = this.options.textArgs;
+            const textKey = this.options.consolidateOptionsWithKey;
 
-            return { text };
+            if (textKey)
+            {
+                return { text: new TextClass({ [textKey]: item, ...style, ...args }) };
+            }
+
+            if (args)
+            {
+                return { text: new TextClass(item, ...args) };
+            }
+
+            return { text: new TextClass(item, style) };
         }
 
         const sprite = Sprite.from(item);

--- a/src/Select.ts
+++ b/src/Select.ts
@@ -54,7 +54,7 @@ type TextSelectOptions = {
     /** Specify which type of content is being used in the dropdown */
     type: 'text';
     /** Override the text class to use, otherwise it will use the default Pixi Text */
-    textClass?: any;
+    textClass?: (...args: any[]) => any;
     /** Specify the text style options */
     textStyle?: Partial<TextStyle>;
     textUpdate?: (view: any, text: string) => void;

--- a/src/Select.ts
+++ b/src/Select.ts
@@ -77,9 +77,14 @@ type TextSelectOptions = {
      * => new TextClass({ arg1, arg2, arg3, label: text })
      */
     consolidateOptionsWithKey?: string;
+    /**
+     * Provide a function to update the text view.
+     * Good for the custom text class that doesn't have a direct text property
+     * that the default update function makes use of.
+     */
+    textUpdate?: (view: any, text: string) => void;
     /** Specify the text style options */
     textStyle?: Partial<TextStyle>;
-    textUpdate?: (view: any, text: string) => void;
     /** Provide an array of text strings for the dropdown */
     items: string[];
 } & BaseSelectOptions;

--- a/src/stories/select/SelectItems.stories.ts
+++ b/src/stories/select/SelectItems.stories.ts
@@ -5,7 +5,6 @@ import { argTypes, getDefaultArgs } from '../utils/argTypes';
 import { Select } from '../../Select';
 import { action } from '@storybook/addon-actions';
 import { preload } from '../utils/loader';
-import { defaultTextStyle } from '../../utils/helpers/styles';
 import { centerElement } from '../../utils/helpers/resize';
 import type { StoryFn } from '@storybook/types';
 import { getColor } from '../utils/color';
@@ -16,50 +15,45 @@ const args = {
     dropDownHoverColor: '#A5E24D',
     fontColor: '#000000',
     fontSize: 28,
-    width: 250,
-    height: 50,
+    width: 200,
+    height: 120,
     radius: 15,
-    itemsAmount: 100,
+    padding: 15,
     onSelect: action('Item selected')
 };
 
-export const UseGraphics: StoryFn = ({
-    fontColor,
-    fontSize,
+export const UseGraphicalItems: StoryFn = ({
     width,
     height,
     radius,
-    itemsAmount,
     backgroundColor,
     dropDownBackgroundColor,
     dropDownHoverColor,
-    onSelect
+    onSelect,
+    padding,
 }: any) =>
 {
     const view = new Container();
 
     backgroundColor = getColor(backgroundColor);
-    fontColor = getColor(fontColor);
     dropDownBackgroundColor = getColor(dropDownBackgroundColor);
     const hoverColor = getColor(dropDownHoverColor);
-    const textStyle = { ...defaultTextStyle, fill: fontColor, fontSize };
-
-    const items = getItems(itemsAmount, 'Item');
+    const items = ['avatar-01.png', 'avatar-02.png', 'avatar-03.png', 'avatar-04.png', 'avatar-05.png'];
 
     // Component usage !!!
     // Important: in order scroll to work, you have to call update() method in your game loop.
     const select = new Select({
-        type: 'text',
+        type: 'sprite',
         closedBG: getClosedBG(backgroundColor, width, height, radius),
         openBG: getOpenBG(dropDownBackgroundColor, width, height, radius),
-        textStyle,
         items,
         itemOptions: {
             backgroundColor,
             hoverColor,
             width,
             height,
-            radius
+            radius,
+            padding,
         },
         scrollBox: {
             width,
@@ -70,10 +64,10 @@ export const UseGraphics: StoryFn = ({
 
     select.y = 10;
 
-    select.onSelect.connect((id, text) =>
+    select.onSelect.connect((_, text) =>
     {
         onSelect({
-            id,
+            id: select.value,
             text
         });
     });
@@ -121,20 +115,8 @@ function getOpenBG(backgroundColor: number, width: number, height: number, radiu
     return openBG;
 }
 
-function getItems(itemsAmount: number, text: string): string[]
-{
-    const items: string[] = [];
-
-    for (let i = 0; i < itemsAmount; i++)
-    {
-        items.push(`${text} ${i + 1}`);
-    }
-
-    return items;
-}
-
 export default {
-    title: 'Components/Select/Use Graphics',
+    title: 'Components/Select/Use Graphical Items',
     argTypes: argTypes(args),
     args: getDefaultArgs(args)
 };

--- a/src/stories/select/SelectSprite.stories.ts
+++ b/src/stories/select/SelectSprite.stories.ts
@@ -35,19 +35,19 @@ export const UseSprite: StoryFn = ({ fontColor, fontSize, itemsAmount, dropDownH
         // Component usage !!!
         // Important: in order scroll to work, you have to call update() method in your game loop.
         select = new Select({
+            type: 'text',
             closedBG: `select_closed.png`,
             openBG: `select_open.png`,
             textStyle,
-            items: {
-                items,
+            items,
+            itemOptions: {
                 backgroundColor: 'RGBA(0, 0, 0, 0.0001)',
                 hoverColor,
                 width: 200,
                 height: 50,
-                textStyle,
-                radius: 25
+                radius: 25,
             },
-            selectedTextOffset: {
+            selectedItemOffset: {
                 y: -13
             },
             scrollBox: {
@@ -63,10 +63,10 @@ export const UseSprite: StoryFn = ({ fontColor, fontSize, itemsAmount, dropDownH
 
         select.y = 10;
 
-        select.onSelect.connect((_, text) =>
+        select.onSelect.connect((id, text) =>
         {
             onSelect({
-                id: select.value,
+                id,
                 text
             });
         });


### PR DESCRIPTION
- A custom `textClass` can be passed in, eg. you can use `I18nLabel` or your own Text wrapper class.
- A `textUpdate` function can also be passed alongside to handle texts that won't update view `textView.text`.
- Add the ability to pass texture aliases or instances to populate the dropdown.
- You now have to explicitly specify which type of content is supported for the dropdown via the new `type` parameter, which will prompt other relevant options .
- Remove unused scrollbox options.
- Add example for the use of sprite items.