### PR TITLE
Feat: add shift scroll and global scroll

### DIFF
--- a/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
@@ -22,6 +22,8 @@ const args = {
     elementsHeight: 80,
     itemsAmount: 100,
     disableEasing: false,
+    globalScroll: true,
+    shiftScroll: false,
     type: [undefined, 'vertical', 'horizontal'],
     onPress: action('Button pressed')
 };
@@ -39,7 +41,9 @@ export const UseGraphics: StoryFn = ({
     backgroundColor,
     disableEasing,
     type,
-    onPress
+    onPress,
+    globalScroll,
+    shiftScroll
 }: any) =>
 {
     const view = new Container();
@@ -76,7 +80,9 @@ export const UseGraphics: StoryFn = ({
         radius,
         padding: elementsPadding,
         disableEasing,
-        type
+        type,
+        globalScroll,
+        shiftScroll
     });
 
     scrollBox.addItems(items);

--- a/src/stories/scrollBox/ScrollBoxSprite.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxSprite.stories.ts
@@ -17,10 +17,14 @@ const args = {
     itemsAmount: 100,
     disableEasing: false,
     type: [undefined, 'vertical', 'horizontal'],
-    onPress: action('Button pressed')
+    onPress: action('Button pressed'),
+    globalScroll: true,
+    shiftScroll: false
 };
 
-export const UseSprite: StoryFn = ({ fontColor, elementsMargin, itemsAmount, onPress, disableEasing, type }: any) =>
+export const UseSprite: StoryFn = ({
+    fontColor, elementsMargin, itemsAmount, onPress, disableEasing, type, globalScroll, shiftScroll
+}: any) =>
 {
     fontColor = getColor(fontColor);
 
@@ -50,7 +54,9 @@ export const UseSprite: StoryFn = ({ fontColor, elementsMargin, itemsAmount, onP
             vertPadding: 18,
             radius: 5,
             disableEasing,
-            type
+            type,
+            globalScroll,
+            shiftScroll
         });
 
         scrollBox.addItems(items);


### PR DESCRIPTION
- Add `globalScroll` option, which when set to `false` only scroll when he pointer is over the top of the scroll box
- Add `shiftScroll` option, which when the scrollbox is horizontal forces the user to use the `shift + scroll` to move the scrollbox, better emulating how scroll boxes work on the browser