### PR TITLE
Fix: Fancy Button Content Fitting

### DIFF
--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -64,6 +64,7 @@ export type ButtonOptions = ViewsInput & {
     iconOffset?: Offset;
     animations?: StateAnimations;
     nineSlicePlane?: [number, number, number, number];
+    ignoreRefitting?: boolean;
 };
 
 /**
@@ -135,6 +136,9 @@ export class FancyButton extends ButtonContainer
 
     /** Anchor point of the button. */
     anchor: ObservablePoint;
+
+    protected _textBaseScale = 1;
+    protected _iconBaseScale = 1;
 
     /**
      * Creates a button with a lot of tweaks.
@@ -298,6 +302,7 @@ export class FancyButton extends ButtonContainer
     protected createTextView(text: AnyText)
     {
         this._views.textView = getTextView(text);
+        this._textBaseScale = this._views.textView.scale.x;
         this._views.textView.anchor.set(0);
         this.innerView.addChild(this._views.textView);
 
@@ -373,6 +378,11 @@ export class FancyButton extends ButtonContainer
 
         if (activeView)
         {
+            if (!this.options.ignoreRefitting)
+            {
+                this._views.textView.scale.set(this._textBaseScale);
+            }
+
             fitToView(activeView, this._views.textView, this.padding);
 
             this._views.textView.x = activeView.x + (activeView.width / 2);
@@ -400,6 +410,11 @@ export class FancyButton extends ButtonContainer
         if (!activeView)
         {
             return;
+        }
+
+        if (!this.options.ignoreRefitting)
+        {
+            this._views.iconView.scale.set(this._iconBaseScale);
         }
 
         fitToView(activeView, this._views.iconView, this.padding);
@@ -626,6 +641,7 @@ export class FancyButton extends ButtonContainer
         }
 
         this._views.iconView = getView(view);
+        this._iconBaseScale = this._views.iconView.scale.x;
 
         if (!this._views.iconView.parent)
         {

--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -62,6 +62,8 @@ export type ButtonOptions = ViewsInput & {
     offset?: Offset;
     textOffset?: Offset;
     iconOffset?: Offset;
+    textScale?: Pos | number;
+    iconScale?: Pos | number;
     animations?: StateAnimations;
     nineSlicePlane?: [number, number, number, number];
     ignoreRefitting?: boolean;
@@ -137,8 +139,11 @@ export class FancyButton extends ButtonContainer
     /** Anchor point of the button. */
     anchor: ObservablePoint;
 
-    protected _textBaseScale = 1;
-    protected _iconBaseScale = 1;
+    /** Base text scaling to take into account when fitting inside the button */
+    protected _textBaseScale: Pos = { x: 1, y: 1 };
+
+    /** Base icon scaling to take into account when fitting inside the button */
+    protected _iconBaseScale: Pos = { x: 1, y: 1 };
 
     /**
      * Creates a button with a lot of tweaks.
@@ -177,6 +182,8 @@ export class FancyButton extends ButtonContainer
             offset,
             textOffset,
             iconOffset,
+            textScale,
+            iconScale,
             scale,
             anchor,
             anchorX,
@@ -194,6 +201,8 @@ export class FancyButton extends ButtonContainer
         this.offset = offset;
         this.textOffset = textOffset;
         this.iconOffset = iconOffset;
+        this.textBaseScale = textScale;
+        this.iconBaseScale = iconScale;
         this.scale.set(scale ?? 1);
 
         if (animations)
@@ -302,7 +311,15 @@ export class FancyButton extends ButtonContainer
     protected createTextView(text: AnyText)
     {
         this._views.textView = getTextView(text);
-        this._textBaseScale = this._views.textView.scale.x;
+
+        // If text scale has not manually been set, we will overwrite the base scale with the new text view scale.
+        if (this.options?.textScale === undefined)
+        {
+            const { x, y } = this._views.textView.scale;
+
+            this._textBaseScale = { x, y };
+        }
+
         this._views.textView.anchor.set(0);
         this.innerView.addChild(this._views.textView);
 
@@ -378,12 +395,12 @@ export class FancyButton extends ButtonContainer
 
         if (activeView)
         {
-            if (!this.options.ignoreRefitting)
+            if (this.options && !this.options.ignoreRefitting)
             {
-                this._views.textView.scale.set(this._textBaseScale);
+                this._views.textView.scale.set(this._textBaseScale.x, this._textBaseScale.y);
             }
 
-            fitToView(activeView, this._views.textView, this.padding);
+            fitToView(activeView, this._views.textView, this.padding, false);
 
             this._views.textView.x = activeView.x + (activeView.width / 2);
             this._views.textView.y = activeView.y + (activeView.height / 2);
@@ -412,12 +429,12 @@ export class FancyButton extends ButtonContainer
             return;
         }
 
-        if (!this.options.ignoreRefitting)
+        if (this.options && !this.options.ignoreRefitting)
         {
-            this._views.iconView.scale.set(this._iconBaseScale);
+            this._views.iconView.scale.set(this._iconBaseScale.x, this._iconBaseScale.y);
         }
 
-        fitToView(activeView, this._views.iconView, this.padding);
+        fitToView(activeView, this._views.iconView, this.padding, false);
 
         (this._views.iconView as Sprite).anchor?.set(0);
 
@@ -641,7 +658,14 @@ export class FancyButton extends ButtonContainer
         }
 
         this._views.iconView = getView(view);
-        this._iconBaseScale = this._views.iconView.scale.x;
+
+        // If icon scale has not manually been set, we will overwrite the base scale with the new icon view scale.
+        if (this.options?.iconScale === undefined)
+        {
+            const { x, y } = this._views.iconView.scale;
+
+            this._iconBaseScale = { x, y };
+        }
 
         if (!this._views.iconView.parent)
         {
@@ -809,6 +833,50 @@ export class FancyButton extends ButtonContainer
     get textOffset(): Offset
     {
         return this._textOffset;
+    }
+
+    /**
+     * Sets the base scale for the text view to take into account when fitting inside the button.
+     * @param {Pos | number} scale - base scale of the text view.
+     */
+    set textBaseScale(scale: Pos | number)
+    {
+        // Apply to the options so that the manual scale is prioritized.
+        this.options.textScale = scale;
+        if (scale === undefined) return;
+        const isNumber = typeof scale === 'number';
+
+        this._textBaseScale.x = isNumber ? scale : scale.x ?? 1;
+        this._textBaseScale.y = isNumber ? scale : scale.y ?? 1;
+        this.adjustTextView(this.state);
+    }
+
+    /** Returns the text view base scale. */
+    get textBaseScale(): Pos
+    {
+        return this.textBaseScale;
+    }
+
+    /**
+     * Sets the base scale for the icon view to take into account when fitting inside the button.
+     * @param {Pos | number} scale - base scale of the icon view.
+     */
+    set iconBaseScale(scale: Pos | number)
+    {
+        // Apply to the options so that the manual scale is prioritized.
+        this.options.iconScale = scale;
+        if (scale === undefined) return;
+        const isNumber = typeof scale === 'number';
+
+        this._iconBaseScale.x = isNumber ? scale : scale.x ?? 1;
+        this._iconBaseScale.y = isNumber ? scale : scale.y ?? 1;
+        this.adjustIconView(this.state);
+    }
+
+    /** Returns the icon view base scale. */
+    get iconBaseScale(): Pos
+    {
+        return this.iconBaseScale;
     }
 
     /**

--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -62,8 +62,8 @@ export type ButtonOptions = ViewsInput & {
     offset?: Offset;
     textOffset?: Offset;
     iconOffset?: Offset;
-    textScale?: Pos | number;
-    iconScale?: Pos | number;
+    defaultTextScale?: Pos | number;
+    defaultIconScale?: Pos | number;
     animations?: StateAnimations;
     nineSlicePlane?: [number, number, number, number];
     ignoreRefitting?: boolean;
@@ -140,10 +140,10 @@ export class FancyButton extends ButtonContainer
     anchor: ObservablePoint;
 
     /** Base text scaling to take into account when fitting inside the button */
-    protected _textBaseScale: Pos = { x: 1, y: 1 };
+    protected _defaultTextScale: Pos = { x: 1, y: 1 };
 
     /** Base icon scaling to take into account when fitting inside the button */
-    protected _iconBaseScale: Pos = { x: 1, y: 1 };
+    protected _defaultIconScale: Pos = { x: 1, y: 1 };
 
     /**
      * Creates a button with a lot of tweaks.
@@ -161,6 +161,8 @@ export class FancyButton extends ButtonContainer
      * @param {Point} options.iconOffset - Offset of the icon view.
      * @param {number} options.scale - Scale of the button. Scale will be applied to a main container,
      * when all animations scales will be applied to the inner view.
+     * @param {number} options.defaultTextScale - Base text scaling to take into account when fitting inside the button.
+     * @param {number} options.defaultIconScale - Base icon scaling to take into account when fitting inside the button.
      * @param {number} options.anchor - Anchor point of the button.
      * @param {number} options.anchorX - Horizontal anchor point of the button.
      * @param {number} options.anchorY - Vertical anchor point of the button.
@@ -182,8 +184,8 @@ export class FancyButton extends ButtonContainer
             offset,
             textOffset,
             iconOffset,
-            textScale,
-            iconScale,
+            defaultTextScale: textScale,
+            defaultIconScale: iconScale,
             scale,
             anchor,
             anchorX,
@@ -201,8 +203,8 @@ export class FancyButton extends ButtonContainer
         this.offset = offset;
         this.textOffset = textOffset;
         this.iconOffset = iconOffset;
-        this.textBaseScale = textScale;
-        this.iconBaseScale = iconScale;
+        this.defaultTextScale = textScale;
+        this.defaultIconScale = iconScale;
         this.scale.set(scale ?? 1);
 
         if (animations)
@@ -313,11 +315,11 @@ export class FancyButton extends ButtonContainer
         this._views.textView = getTextView(text);
 
         // If text scale has not manually been set, we will overwrite the base scale with the new text view scale.
-        if (this.options?.textScale === undefined)
+        if (this.options?.defaultTextScale === undefined)
         {
             const { x, y } = this._views.textView.scale;
 
-            this._textBaseScale = { x, y };
+            this._defaultTextScale = { x, y };
         }
 
         this._views.textView.anchor.set(0);
@@ -397,7 +399,7 @@ export class FancyButton extends ButtonContainer
         {
             if (!this.options?.ignoreRefitting)
             {
-                this._views.textView.scale.set(this._textBaseScale.x, this._textBaseScale.y);
+                this._views.textView.scale.set(this._defaultTextScale.x, this._defaultTextScale.y);
             }
 
             fitToView(activeView, this._views.textView, this.padding, false);
@@ -431,7 +433,7 @@ export class FancyButton extends ButtonContainer
 
         if (!this.options?.ignoreRefitting)
         {
-            this._views.iconView.scale.set(this._iconBaseScale.x, this._iconBaseScale.y);
+            this._views.iconView.scale.set(this._defaultIconScale.x, this._defaultIconScale.y);
         }
 
         fitToView(activeView, this._views.iconView, this.padding, false);
@@ -660,11 +662,11 @@ export class FancyButton extends ButtonContainer
         this._views.iconView = getView(view);
 
         // If icon scale has not manually been set, we will overwrite the base scale with the new icon view scale.
-        if (this.options?.iconScale === undefined)
+        if (this.options?.defaultIconScale === undefined)
         {
             const { x, y } = this._views.iconView.scale;
 
-            this._iconBaseScale = { x, y };
+            this._defaultIconScale = { x, y };
         }
 
         if (!this._views.iconView.parent)
@@ -839,44 +841,44 @@ export class FancyButton extends ButtonContainer
      * Sets the base scale for the text view to take into account when fitting inside the button.
      * @param {Pos | number} scale - base scale of the text view.
      */
-    set textBaseScale(scale: Pos | number)
+    set defaultTextScale(scale: Pos | number)
     {
         if (scale === undefined) return;
         // Apply to the options so that the manual scale is prioritized.
-        this.options.textScale = scale;
+        this.options.defaultTextScale = scale;
         const isNumber = typeof scale === 'number';
 
-        this._textBaseScale.x = isNumber ? scale : scale.x ?? 1;
-        this._textBaseScale.y = isNumber ? scale : scale.y ?? 1;
+        this._defaultTextScale.x = isNumber ? scale : scale.x ?? 1;
+        this._defaultTextScale.y = isNumber ? scale : scale.y ?? 1;
         this.adjustTextView(this.state);
     }
 
     /** Returns the text view base scale. */
-    get textBaseScale(): Pos
+    get defaultTextScale(): Pos
     {
-        return this.textBaseScale;
+        return this.defaultTextScale;
     }
 
     /**
      * Sets the base scale for the icon view to take into account when fitting inside the button.
      * @param {Pos | number} scale - base scale of the icon view.
      */
-    set iconBaseScale(scale: Pos | number)
+    set defaultIconScale(scale: Pos | number)
     {
         if (scale === undefined) return;
         // Apply to the options so that the manual scale is prioritized.
-        this.options.iconScale = scale;
+        this.options.defaultIconScale = scale;
         const isNumber = typeof scale === 'number';
 
-        this._iconBaseScale.x = isNumber ? scale : scale.x ?? 1;
-        this._iconBaseScale.y = isNumber ? scale : scale.y ?? 1;
+        this._defaultIconScale.x = isNumber ? scale : scale.x ?? 1;
+        this._defaultIconScale.y = isNumber ? scale : scale.y ?? 1;
         this.adjustIconView(this.state);
     }
 
     /** Returns the icon view base scale. */
-    get iconBaseScale(): Pos
+    get defaultIconScale(): Pos
     {
-        return this.iconBaseScale;
+        return this.defaultIconScale;
     }
 
     /**

--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -841,6 +841,7 @@ export class FancyButton extends ButtonContainer
      */
     set textBaseScale(scale: Pos | number)
     {
+        if (!this.options) return;
         // Apply to the options so that the manual scale is prioritized.
         this.options.textScale = scale;
         if (scale === undefined) return;
@@ -863,6 +864,7 @@ export class FancyButton extends ButtonContainer
      */
     set iconBaseScale(scale: Pos | number)
     {
+        if (!this.options) return;
         // Apply to the options so that the manual scale is prioritized.
         this.options.iconScale = scale;
         if (scale === undefined) return;

--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -170,7 +170,7 @@ export class FancyButton extends ButtonContainer
     {
         super();
 
-        this.options = options;
+        this.options = options ?? {};
 
         const {
             defaultView,
@@ -395,7 +395,7 @@ export class FancyButton extends ButtonContainer
 
         if (activeView)
         {
-            if (this.options && !this.options.ignoreRefitting)
+            if (!this.options?.ignoreRefitting)
             {
                 this._views.textView.scale.set(this._textBaseScale.x, this._textBaseScale.y);
             }
@@ -429,7 +429,7 @@ export class FancyButton extends ButtonContainer
             return;
         }
 
-        if (this.options && !this.options.ignoreRefitting)
+        if (!this.options?.ignoreRefitting)
         {
             this._views.iconView.scale.set(this._iconBaseScale.x, this._iconBaseScale.y);
         }
@@ -841,10 +841,9 @@ export class FancyButton extends ButtonContainer
      */
     set textBaseScale(scale: Pos | number)
     {
-        if (!this.options) return;
+        if (scale === undefined) return;
         // Apply to the options so that the manual scale is prioritized.
         this.options.textScale = scale;
-        if (scale === undefined) return;
         const isNumber = typeof scale === 'number';
 
         this._textBaseScale.x = isNumber ? scale : scale.x ?? 1;
@@ -864,10 +863,9 @@ export class FancyButton extends ButtonContainer
      */
     set iconBaseScale(scale: Pos | number)
     {
-        if (!this.options) return;
+        if (scale === undefined) return;
         // Apply to the options so that the manual scale is prioritized.
         this.options.iconScale = scale;
-        if (scale === undefined) return;
         const isNumber = typeof scale === 'number';
 
         this._iconBaseScale.x = isNumber ? scale : scale.x ?? 1;

--- a/src/stories/fancyButton/FancyButtonBitmapText.stories.ts
+++ b/src/stories/fancyButton/FancyButtonBitmapText.stories.ts
@@ -13,6 +13,7 @@ const args = {
     padding: 11,
     textOffsetX: 0,
     textOffsetY: -7,
+    defaultTextScale: 0.99,
     anchorX: 0.5,
     anchorY: 0.5,
     animationDuration: 100,
@@ -28,6 +29,7 @@ export const UsingSpriteAndBitmapText = ({
     padding,
     textOffsetX,
     textOffsetY,
+    defaultTextScale,
     anchorX,
     anchorY,
     animationDuration
@@ -55,6 +57,7 @@ export const UsingSpriteAndBitmapText = ({
             text: title,
             padding,
             textOffset: { x: textOffsetX, y: textOffsetY },
+            defaultTextScale,
             animations: {
                 hover: {
                     props: {

--- a/src/stories/fancyButton/FancyButtonDynamicUpdate.stories.ts
+++ b/src/stories/fancyButton/FancyButtonDynamicUpdate.stories.ts
@@ -1,13 +1,13 @@
+import { Container } from '@pixi/display';
+import { Sprite } from '@pixi/sprite';
+import { Text } from '@pixi/text';
 import { FancyButton } from '../../FancyButton';
-import { action } from '@storybook/addon-actions';
+import { centerView } from '../../utils/helpers/resize';
+import { defaultTextStyle } from '../../utils/helpers/styles';
 import { argTypes, getDefaultArgs } from '../utils/argTypes';
 import { preload } from '../utils/loader';
-import { centerView } from '../../utils/helpers/resize';
-import { Container } from '@pixi/display';
-import { defaultTextStyle } from '../../utils/helpers/styles';
-import { Text } from '@pixi/text';
 import { randomItem } from '../utils/random';
-import { Sprite } from '@pixi/sprite';
+import { action } from '@storybook/addon-actions';
 
 const args = {
     text: 'Click me!',
@@ -45,7 +45,7 @@ export const DynamicUpdate = ({
         let icon = avatars[0];
 
         button.iconView = Sprite.from(icon);
-        button.iconView.scale.set(0.2);
+        button.iconBaseScale = 0.2;
         button.iconOffset = { x: -100, y: -7 };
 
         button.textView = new Text(text, {

--- a/src/stories/fancyButton/FancyButtonDynamicUpdate.stories.ts
+++ b/src/stories/fancyButton/FancyButtonDynamicUpdate.stories.ts
@@ -12,6 +12,8 @@ import { action } from '@storybook/addon-actions';
 const args = {
     text: 'Click me!',
     textColor: '#FFFFFF',
+    defaultTextScale: 0.99,
+    defaultIconScale: 0.2,
     padding: 11,
     anchorX: 0.5,
     anchorY: 0.5,
@@ -22,6 +24,8 @@ const args = {
 export const DynamicUpdate = ({
     text,
     textColor,
+    defaultTextScale,
+    defaultIconScale,
     disabled,
     onPress,
     padding,
@@ -45,13 +49,14 @@ export const DynamicUpdate = ({
         let icon = avatars[0];
 
         button.iconView = Sprite.from(icon);
-        button.defaultIconScale = 0.2;
+        button.defaultIconScale = defaultIconScale;
         button.iconOffset = { x: -100, y: -7 };
 
         button.textView = new Text(text, {
             ...defaultTextStyle,
             fill: textColor || defaultTextStyle.fill
         });
+        button.defaultTextScale = defaultTextScale;
         button.textOffset = { x: 30, y: -7 };
 
         button.padding = padding;

--- a/src/stories/fancyButton/FancyButtonDynamicUpdate.stories.ts
+++ b/src/stories/fancyButton/FancyButtonDynamicUpdate.stories.ts
@@ -45,7 +45,7 @@ export const DynamicUpdate = ({
         let icon = avatars[0];
 
         button.iconView = Sprite.from(icon);
-        button.iconBaseScale = 0.2;
+        button.defaultIconScale = 0.2;
         button.iconOffset = { x: -100, y: -7 };
 
         button.textView = new Text(text, {

--- a/src/stories/fancyButton/FancyButtonGraphics.stories.ts
+++ b/src/stories/fancyButton/FancyButtonGraphics.stories.ts
@@ -26,6 +26,8 @@ const args = {
     iconOffsetY: -30,
     textOffsetX: 0,
     textOffsetY: 140,
+    defaultTextScale: 0.99,
+    defaultIconScale: 0.99,
     defaultOffsetY: 0,
     hoverOffsetY: -1,
     pressedOffsetY: 5,
@@ -55,6 +57,8 @@ export const UseGraphics = ({
     iconOffsetY,
     textOffsetX,
     textOffsetY,
+    defaultTextScale,
+    defaultIconScale,
     defaultOffsetY,
     hoverOffsetY,
     pressedOffsetY,
@@ -111,6 +115,8 @@ export const UseGraphics = ({
                 x: iconOffsetX,
                 y: iconOffsetY
             },
+            defaultTextScale,
+            defaultIconScale,
             animations: {
                 default: {
                     props: {

--- a/src/stories/fancyButton/FancyButtonHTMLText.stories.ts
+++ b/src/stories/fancyButton/FancyButtonHTMLText.stories.ts
@@ -13,6 +13,7 @@ const args = {
     padding: 11,
     textOffsetX: 0,
     textOffsetY: -7,
+    defaultTextScale: 0.99,
     anchorX: 0.5,
     anchorY: 0.5,
     animationDuration: 100,
@@ -28,6 +29,7 @@ export const UsingSpriteAndHTMLText = ({
     padding,
     textOffsetX,
     textOffsetY,
+    defaultTextScale,
     anchorX,
     anchorY,
     animationDuration
@@ -53,6 +55,7 @@ export const UsingSpriteAndHTMLText = ({
             text: title,
             padding,
             textOffset: { x: textOffsetX, y: textOffsetY },
+            defaultTextScale,
             animations: {
                 hover: {
                     props: {

--- a/src/stories/fancyButton/FancyButtonIcon.stories.ts
+++ b/src/stories/fancyButton/FancyButtonIcon.stories.ts
@@ -20,6 +20,7 @@ const args = {
     radius: 200,
     iconOffsetX: 0,
     iconOffsetY: 0,
+    defaultIconScale: 0.99,
     defaultOffset: 0,
     hoverOffset: -1,
     pressedOffset: 5,
@@ -43,6 +44,7 @@ export const UseIcon = ({
     padding,
     iconOffsetX,
     iconOffsetY,
+    defaultIconScale,
     defaultOffset,
     hoverOffset,
     pressedOffset,
@@ -80,6 +82,7 @@ export const UseIcon = ({
             pressedView: new Graphics().beginFill(pressedColor).drawRoundedRect(0, 0, width, height, radius),
             disabledView: new Graphics().beginFill(disabledColor).drawRoundedRect(0, 0, width, height, radius),
             icon,
+            defaultIconScale,
             padding,
             offset: {
                 default: { y: defaultOffset },

--- a/src/stories/fancyButton/FancyButtonNineSlicePlaneSprite.stories.ts
+++ b/src/stories/fancyButton/FancyButtonNineSlicePlaneSprite.stories.ts
@@ -80,13 +80,16 @@ export const UseNineSlicePlane = ({
             },
         });
 
-        button.iconView = new MaskedFrame({
+        const buttonIcon = new MaskedFrame({
             target: `avatar-01.png`,
             mask: `avatar_mask.png`,
             borderWidth: 10,
             borderColor: 0xFFFFFF
         });
-        button.iconView.scale.set(0.2);
+
+        buttonIcon.scale.set(0.2);
+
+        button.iconView = buttonIcon;
         button.iconOffset = { x: -100, y: -7 };
 
         button.anchor.set(anchorX, anchorY);

--- a/src/stories/fancyButton/FancyButtonNineSlicePlaneSprite.stories.ts
+++ b/src/stories/fancyButton/FancyButtonNineSlicePlaneSprite.stories.ts
@@ -69,7 +69,7 @@ export const UseNineSlicePlane = ({
             padding,
             textOffset: { x: 30, y: -5 },
             iconOffset: { x: -100, y: -7 },
-            iconScale: 0.2,
+            defaultIconScale: 0.2,
             animations: {
                 hover: {
                     props: {

--- a/src/stories/fancyButton/FancyButtonNineSlicePlaneSprite.stories.ts
+++ b/src/stories/fancyButton/FancyButtonNineSlicePlaneSprite.stories.ts
@@ -14,6 +14,8 @@ const args = {
     padding: 11,
     width: 300,
     height: 137,
+    defaultTextScale: 0.99,
+    defaultIconScale: 0.2,
     anchorX: 0.5,
     anchorY: 0.5,
     animationDuration: 100,
@@ -31,7 +33,9 @@ export const UseNineSlicePlane = ({
     anchorY,
     animationDuration,
     width,
-    height
+    height,
+    defaultTextScale,
+    defaultIconScale,
 }: any) =>
 {
     const view = new Container();
@@ -69,7 +73,8 @@ export const UseNineSlicePlane = ({
             padding,
             textOffset: { x: 30, y: -5 },
             iconOffset: { x: -100, y: -7 },
-            defaultIconScale: 0.2,
+            defaultTextScale,
+            defaultIconScale,
             animations: {
                 hover: {
                     props: {

--- a/src/stories/fancyButton/FancyButtonNineSlicePlaneSprite.stories.ts
+++ b/src/stories/fancyButton/FancyButtonNineSlicePlaneSprite.stories.ts
@@ -60,8 +60,16 @@ export const UseNineSlicePlane = ({
                 ...defaultTextStyle,
                 fill: textColor || defaultTextStyle.fill
             }),
+            icon: new MaskedFrame({
+                target: `avatar-01.png`,
+                mask: `avatar_mask.png`,
+                borderWidth: 10,
+                borderColor: 0xFFFFFF
+            }),
             padding,
             textOffset: { x: 30, y: -5 },
+            iconOffset: { x: -100, y: -7 },
+            iconScale: 0.2,
             animations: {
                 hover: {
                     props: {
@@ -79,18 +87,6 @@ export const UseNineSlicePlane = ({
                 }
             },
         });
-
-        const buttonIcon = new MaskedFrame({
-            target: `avatar-01.png`,
-            mask: `avatar_mask.png`,
-            borderWidth: 10,
-            borderColor: 0xFFFFFF
-        });
-
-        buttonIcon.scale.set(0.2);
-
-        button.iconView = buttonIcon;
-        button.iconOffset = { x: -100, y: -7 };
 
         button.anchor.set(anchorX, anchorY);
 

--- a/src/stories/fancyButton/FancyButtonSprite.stories.ts
+++ b/src/stories/fancyButton/FancyButtonSprite.stories.ts
@@ -13,6 +13,7 @@ const args = {
     padding: 11,
     textOffsetX: 0,
     textOffsetY: -7,
+    defaultTextScale: 0.99,
     anchorX: 0.5,
     anchorY: 0.5,
     animationDuration: 100,
@@ -28,6 +29,7 @@ export const UseSprite = ({
     padding,
     textOffsetX,
     textOffsetY,
+    defaultTextScale,
     anchorX,
     anchorY,
     animationDuration
@@ -51,6 +53,7 @@ export const UseSprite = ({
             }),
             padding,
             textOffset: { x: textOffsetX, y: textOffsetY },
+            defaultTextScale,
             animations: {
                 hover: {
                     props: {

--- a/src/utils/helpers/fit.ts
+++ b/src/utils/helpers/fit.ts
@@ -1,6 +1,6 @@
 import { Container } from '@pixi/display';
 
-export function fitToView(parent: Container, child: Container, padding = 0)
+export function fitToView(parent: Container, child: Container, padding = 0, uniformScaling = true)
 {
     let scaleX = child.scale.x;
     let scaleY = child.scale.y;
@@ -18,18 +18,38 @@ export function fitToView(parent: Container, child: Container, padding = 0)
 
     if (widthOverflow < 0)
     {
-        scaleX = maxWidth / (child.width * scaleX);
+        scaleX = maxWidth / (child.width / scaleX);
     }
 
     if (heightOverflow < 0)
     {
-        scaleY = maxHeight / (child.height * scaleY);
+        scaleY = maxHeight / (child.height / scaleY);
     }
 
     if (scaleX <= 0 || scaleY <= 0)
     {
-        child.visible = false;
+        child.scale.set(0);
+
+        return;
     }
 
-    child.scale.set(Math.min(scaleX, scaleY));
+    if (uniformScaling || child.scale.x === child.scale.y)
+    {
+        const scale = Math.min(scaleX, scaleY);
+
+        child.scale.set(scale, scale);
+    }
+    else
+    {
+        const ratio = child.scale.x / child.scale.y;
+
+        if (widthOverflow < heightOverflow)
+        {
+            child.scale.set(scaleX, scaleX / ratio);
+        }
+        else
+        {
+            child.scale.set(scaleY * ratio, scaleY);
+        }
+    }
 }


### PR DESCRIPTION
- Reset text/icon view scaling back to the default scale before doing the `fitToView` call to prevent the persistent of scale < 1 from the initial fitting.
    eg. if the button default view texture has a width of 150 and the content text has a width of 200, it will apply 0.75 scaling to the text view to fit it within the button (assuming that the padding is 0). Then if the button width is then set to 250, the text will still remain at 0.75 despite that it no longer needed to be scaled down to fit within the button.
- A `ignoreRefitting` is provided in case the persistent scaling behaviour from before is preferred.
- Add the ability to pass in the base scale for text and icon at instantiation. This will be prioritise over the automatic extraction from the new text or icon views.
- Add the ability to disable uniform scaling on the `fitToView` function to allow the child to maintain its aspect ratio from before the fitting.