### PR TITLE
Feat: add text and icon default anchor options

### DIFF
--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -1,6 +1,7 @@
+/* eslint-disable max-len */
 import { ObservablePoint, Ticker, Rectangle, utils, Texture } from '@pixi/core';
 import { Container } from '@pixi/display';
-import type { Sprite } from '@pixi/sprite';
+import { Sprite } from '@pixi/sprite';
 import { getView } from './utils/helpers/view';
 import { AnyText, getTextView, PixiText } from './utils/helpers/text';
 import { fitToView } from './utils/helpers/fit';
@@ -64,6 +65,8 @@ export type ButtonOptions = ViewsInput & {
     iconOffset?: Offset;
     defaultTextScale?: Pos | number;
     defaultIconScale?: Pos | number;
+    defaultTextAnchor?: Pos | number;
+    defaultIconAnchor?: Pos | number;
     animations?: StateAnimations;
     nineSlicePlane?: [number, number, number, number];
     ignoreRefitting?: boolean;
@@ -145,6 +148,12 @@ export class FancyButton extends ButtonContainer
     /** Base icon scaling to take into account when fitting inside the button */
     protected _defaultIconScale: Pos = { x: 1, y: 1 };
 
+    /** Base text anchor to take into account when fitting and placing inside the button */
+    protected _defaultTextAnchor: Pos = { x: 0.5, y: 0.5 };
+
+    /** Base icon anchor to take into account when fitting and placing inside the button */
+    protected _defaultIconAnchor: Pos = { x: 0.5, y: 0.5 };
+
     /**
      * Creates a button with a lot of tweaks.
      * @param {object} options - Button options.
@@ -163,6 +172,8 @@ export class FancyButton extends ButtonContainer
      * when all animations scales will be applied to the inner view.
      * @param {number} options.defaultTextScale - Base text scaling to take into account when fitting inside the button.
      * @param {number} options.defaultIconScale - Base icon scaling to take into account when fitting inside the button.
+     * @param {number} options.defaultTextAnchor - Base text anchor to take into account when fitting and placing inside the button.
+     * @param {number} options.defaultIconAnchor - Base icon anchor to take into account when fitting and placing inside the button.
      * @param {number} options.anchor - Anchor point of the button.
      * @param {number} options.anchorX - Horizontal anchor point of the button.
      * @param {number} options.anchorY - Vertical anchor point of the button.
@@ -186,6 +197,8 @@ export class FancyButton extends ButtonContainer
             iconOffset,
             defaultTextScale: textScale,
             defaultIconScale: iconScale,
+            defaultTextAnchor: textAnchor,
+            defaultIconAnchor: iconAnchor,
             scale,
             anchor,
             anchorX,
@@ -205,6 +218,8 @@ export class FancyButton extends ButtonContainer
         this.iconOffset = iconOffset;
         this.defaultTextScale = textScale;
         this.defaultIconScale = iconScale;
+        this.defaultTextAnchor = textAnchor;
+        this.defaultIconAnchor = iconAnchor;
         this.scale.set(scale ?? 1);
 
         if (animations)
@@ -322,7 +337,6 @@ export class FancyButton extends ButtonContainer
             this._defaultTextScale = { x, y };
         }
 
-        this._views.textView.anchor.set(0);
         this.innerView.addChild(this._views.textView);
 
         this.adjustTextView(this.state);
@@ -394,6 +408,7 @@ export class FancyButton extends ButtonContainer
         if (!this.text) return;
 
         const activeView = this.getStateView(this.state);
+        const { x: anchorX, y: anchorY } = this._defaultTextAnchor;
 
         if (activeView)
         {
@@ -408,7 +423,7 @@ export class FancyButton extends ButtonContainer
             this._views.textView.y = activeView.y + (activeView.height / 2);
         }
 
-        this._views.textView.anchor.set(0.5);
+        this._views.textView.anchor.set(anchorX, anchorY);
 
         this.setOffset(this._views.textView, state, this.textOffset);
     }
@@ -436,12 +451,24 @@ export class FancyButton extends ButtonContainer
             this._views.iconView.scale.set(this._defaultIconScale.x, this._defaultIconScale.y);
         }
 
+        const { x: anchorX, y: anchorY } = this._defaultIconAnchor;
+
         fitToView(activeView, this._views.iconView, this.padding, false);
 
-        (this._views.iconView as Sprite).anchor?.set(0);
+        if ('anchor' in this._views.iconView)
+        {
+            (this._views.iconView.anchor as ObservablePoint).set(anchorX, anchorY);
+        }
+        else
+        {
+            this._views.iconView.pivot.set(
+                anchorX * (this._views.iconView.width / this._views.iconView.scale.x),
+                anchorY * (this._views.iconView.height / this._views.iconView.scale.y)
+            );
+        }
 
-        this._views.iconView.x = activeView.x + (activeView.width / 2) - (this._views.iconView.width / 2);
-        this._views.iconView.y = activeView.y + (activeView.height / 2) - (this._views.iconView.height / 2);
+        this._views.iconView.x = activeView.x + (activeView.width / 2);
+        this._views.iconView.y = activeView.y + (activeView.height / 2);
 
         this.setOffset(this._views.iconView, state, this.iconOffset);
     }
@@ -879,6 +906,50 @@ export class FancyButton extends ButtonContainer
     get defaultIconScale(): Pos
     {
         return this.defaultIconScale;
+    }
+
+    /**
+     * Sets the base anchor for the text view to take into account when fitting and placing inside the button.
+     * @param {Pos | number} anchor - base anchor of the text view.
+     */
+    set defaultTextAnchor(anchor: Pos | number)
+    {
+        if (anchor === undefined) return;
+        // Apply to the options so that the manual anchor is prioritized.
+        this.options.defaultTextAnchor = anchor;
+        const isNumber = typeof anchor === 'number';
+
+        this._defaultTextAnchor.x = isNumber ? anchor : anchor.x ?? 1;
+        this._defaultTextAnchor.y = isNumber ? anchor : anchor.y ?? 1;
+        this.adjustTextView(this.state);
+    }
+
+    /** Returns the text view base anchor. */
+    get defaultTextAnchor(): Pos
+    {
+        return this.defaultTextAnchor;
+    }
+
+    /**
+     * Sets the base anchor for the icon view to take into account when fitting and placing inside the button.
+     * @param {Pos | number} anchor - base anchor of the icon view.
+     */
+    set defaultIconAnchor(anchor: Pos | number)
+    {
+        if (anchor === undefined) return;
+        // Apply to the options so that the manual anchor is prioritized.
+        this.options.defaultIconAnchor = anchor;
+        const isNumber = typeof anchor === 'number';
+
+        this._defaultIconAnchor.x = isNumber ? anchor : anchor.x ?? 1;
+        this._defaultIconAnchor.y = isNumber ? anchor : anchor.y ?? 1;
+        this.adjustIconView(this.state);
+    }
+
+    /** Returns the icon view base anchor. */
+    get defaultIconAnchor(): Pos
+    {
+        return this.defaultIconAnchor;
     }
 
     /**

--- a/src/stories/fancyButton/FancyButtonBitmapText.stories.ts
+++ b/src/stories/fancyButton/FancyButtonBitmapText.stories.ts
@@ -14,6 +14,8 @@ const args = {
     textOffsetX: 0,
     textOffsetY: -7,
     defaultTextScale: 0.99,
+    defaultTextAnchorX: 0.5,
+    defaultTextAnchorY: 0.5,
     anchorX: 0.5,
     anchorY: 0.5,
     animationDuration: 100,
@@ -30,6 +32,8 @@ export const UsingSpriteAndBitmapText = ({
     textOffsetX,
     textOffsetY,
     defaultTextScale,
+    defaultTextAnchorX,
+    defaultTextAnchorY,
     anchorX,
     anchorY,
     animationDuration
@@ -58,6 +62,7 @@ export const UsingSpriteAndBitmapText = ({
             padding,
             textOffset: { x: textOffsetX, y: textOffsetY },
             defaultTextScale,
+            defaultTextAnchor: { x: defaultTextAnchorX, y: defaultTextAnchorY },
             animations: {
                 hover: {
                     props: {

--- a/src/stories/fancyButton/FancyButtonDynamicUpdate.stories.ts
+++ b/src/stories/fancyButton/FancyButtonDynamicUpdate.stories.ts
@@ -14,6 +14,10 @@ const args = {
     textColor: '#FFFFFF',
     defaultTextScale: 0.99,
     defaultIconScale: 0.2,
+    defaultTextAnchorX: 0.5,
+    defaultTextAnchorY: 0.5,
+    defaultIconAnchorX: 0.5,
+    defaultIconAnchorY: 0.5,
     padding: 11,
     anchorX: 0.5,
     anchorY: 0.5,
@@ -26,6 +30,10 @@ export const DynamicUpdate = ({
     textColor,
     defaultTextScale,
     defaultIconScale,
+    defaultTextAnchorX,
+    defaultTextAnchorY,
+    defaultIconAnchorX,
+    defaultIconAnchorY,
     disabled,
     onPress,
     padding,
@@ -50,6 +58,7 @@ export const DynamicUpdate = ({
 
         button.iconView = Sprite.from(icon);
         button.defaultIconScale = defaultIconScale;
+        button.defaultIconAnchor = { x: defaultIconAnchorX, y: defaultIconAnchorY };
         button.iconOffset = { x: -100, y: -7 };
 
         button.textView = new Text(text, {
@@ -57,6 +66,7 @@ export const DynamicUpdate = ({
             fill: textColor || defaultTextStyle.fill
         });
         button.defaultTextScale = defaultTextScale;
+        button.defaultTextAnchor = { x: defaultTextAnchorX, y: defaultTextAnchorY };
         button.textOffset = { x: 30, y: -7 };
 
         button.padding = padding;

--- a/src/stories/fancyButton/FancyButtonGraphics.stories.ts
+++ b/src/stories/fancyButton/FancyButtonGraphics.stories.ts
@@ -28,6 +28,10 @@ const args = {
     textOffsetY: 140,
     defaultTextScale: 0.99,
     defaultIconScale: 0.99,
+    defaultTextAnchorX: 0.5,
+    defaultTextAnchorY: 0.5,
+    defaultIconAnchorX: 0.5,
+    defaultIconAnchorY: 0.5,
     defaultOffsetY: 0,
     hoverOffsetY: -1,
     pressedOffsetY: 5,
@@ -59,6 +63,10 @@ export const UseGraphics = ({
     textOffsetY,
     defaultTextScale,
     defaultIconScale,
+    defaultTextAnchorX,
+    defaultTextAnchorY,
+    defaultIconAnchorX,
+    defaultIconAnchorY,
     defaultOffsetY,
     hoverOffsetY,
     pressedOffsetY,
@@ -117,6 +125,14 @@ export const UseGraphics = ({
             },
             defaultTextScale,
             defaultIconScale,
+            defaultTextAnchor: {
+                x: defaultTextAnchorX,
+                y: defaultTextAnchorY
+            },
+            defaultIconAnchor: {
+                x: defaultIconAnchorX,
+                y: defaultIconAnchorY
+            },
             animations: {
                 default: {
                     props: {

--- a/src/stories/fancyButton/FancyButtonHTMLText.stories.ts
+++ b/src/stories/fancyButton/FancyButtonHTMLText.stories.ts
@@ -14,6 +14,8 @@ const args = {
     textOffsetX: 0,
     textOffsetY: -7,
     defaultTextScale: 0.99,
+    defaultTextAnchorX: 0.5,
+    defaultTextAnchorY: 0.5,
     anchorX: 0.5,
     anchorY: 0.5,
     animationDuration: 100,
@@ -30,6 +32,8 @@ export const UsingSpriteAndHTMLText = ({
     textOffsetX,
     textOffsetY,
     defaultTextScale,
+    defaultTextAnchorX,
+    defaultTextAnchorY,
     anchorX,
     anchorY,
     animationDuration
@@ -56,6 +60,7 @@ export const UsingSpriteAndHTMLText = ({
             padding,
             textOffset: { x: textOffsetX, y: textOffsetY },
             defaultTextScale,
+            defaultTextAnchor: { x: defaultTextAnchorX, y: defaultTextAnchorY },
             animations: {
                 hover: {
                     props: {

--- a/src/stories/fancyButton/FancyButtonNineSlicePlaneSprite.stories.ts
+++ b/src/stories/fancyButton/FancyButtonNineSlicePlaneSprite.stories.ts
@@ -16,6 +16,10 @@ const args = {
     height: 137,
     defaultTextScale: 0.99,
     defaultIconScale: 0.2,
+    defaultTextAnchorX: 0.5,
+    defaultTextAnchorY: 0.5,
+    defaultIconAnchorX: 0.5,
+    defaultIconAnchorY: 0.5,
     anchorX: 0.5,
     anchorY: 0.5,
     animationDuration: 100,
@@ -36,6 +40,10 @@ export const UseNineSlicePlane = ({
     height,
     defaultTextScale,
     defaultIconScale,
+    defaultTextAnchorX,
+    defaultTextAnchorY,
+    defaultIconAnchorX,
+    defaultIconAnchorY
 }: any) =>
 {
     const view = new Container();
@@ -75,6 +83,8 @@ export const UseNineSlicePlane = ({
             iconOffset: { x: -100, y: -7 },
             defaultTextScale,
             defaultIconScale,
+            defaultTextAnchor: { x: defaultTextAnchorX, y: defaultTextAnchorY },
+            defaultIconAnchor: { x: defaultIconAnchorX, y: defaultIconAnchorY },
             animations: {
                 hover: {
                     props: {

--- a/src/stories/fancyButton/FancyButtonSprite.stories.ts
+++ b/src/stories/fancyButton/FancyButtonSprite.stories.ts
@@ -14,6 +14,8 @@ const args = {
     textOffsetX: 0,
     textOffsetY: -7,
     defaultTextScale: 0.99,
+    defaultTextAnchorX: 0.5,
+    defaultTextAnchorY: 0.5,
     anchorX: 0.5,
     anchorY: 0.5,
     animationDuration: 100,
@@ -30,6 +32,8 @@ export const UseSprite = ({
     textOffsetX,
     textOffsetY,
     defaultTextScale,
+    defaultTextAnchorX,
+    defaultTextAnchorY,
     anchorX,
     anchorY,
     animationDuration
@@ -54,6 +58,7 @@ export const UseSprite = ({
             padding,
             textOffset: { x: textOffsetX, y: textOffsetY },
             defaultTextScale,
+            defaultTextAnchor: { x: defaultTextAnchorX, y: defaultTextAnchorY },
             animations: {
                 hover: {
                     props: {


### PR DESCRIPTION
- Allow the individually setting of default anchor of the content components, ie. the text and icon.
- If not specified, the anchor for both will be 0.5 on both axes.
- This can be useful for situations where you want to align the dynamic content to one side, eg. an localised text aligning left at a fix point on the button, pairing nicely with the offset options.
- Examples have been updated with these new anchor options.