### PR TITLE
Feat: ScrollBox Item Proximity Event

### DIFF
--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -769,31 +769,31 @@ export class ScrollBox extends Container
     }
 
     private checkItemProximity(item: Container, index: number): void
+    {
+        /** Get the item bounds, capping the width and height to at least 1 for the purposes of intersection checking. */
+        item.getBounds(true, itemBounds);
+        itemBounds.width = Math.max(itemBounds.width, 1);
+        itemBounds.height = Math.max(itemBounds.height, 1);
+
+        // Get the scroller bounds, expanding them by the defined max distance.
+        this.borderMask.getBounds(true, scrollerBounds);
+
+        scrollerBounds.x -= this.proximityRange;
+        scrollerBounds.y -= this.proximityRange;
+        scrollerBounds.width += this.proximityRange * 2;
+        scrollerBounds.height += this.proximityRange * 2;
+
+        // Check for intersection
+        const inRange = scrollerBounds.intersects(itemBounds);
+        const wasInRange = this.proximityCache[index];
+
+        // If the item's proximity state has changed, emit the event
+        if (inRange !== wasInRange)
         {
-            /** Get the item bounds, capping the width and height to at least 1 for the purposes of intersection checking. */
-            item.getBounds(true, itemBounds);
-            itemBounds.width = Math.max(itemBounds.width, 1);
-            itemBounds.height = Math.max(itemBounds.height, 1);
-    
-            // Get the scroller bounds, expanding them by the defined max distance.
-            this.borderMask.getBounds(true, scrollerBounds);
-    
-            scrollerBounds.x -= this.proximityRange;
-            scrollerBounds.y -= this.proximityRange;
-            scrollerBounds.width += this.proximityRange * 2;
-            scrollerBounds.height += this.proximityRange * 2;
-    
-            // Check for intersection
-            const inRange = scrollerBounds.intersects(itemBounds);
-            const wasInRange = this.proximityCache[index];
-    
-            // If the item's proximity state has changed, emit the event
-            if (inRange !== wasInRange)
-            {
-                this.proximityCache[index] = inRange;
-                this.onProximityChange.emit({ item, index, inRange });
-            }
+            this.proximityCache[index] = inRange;
+            this.onProximityChange.emit({ item, index, inRange });
         }
+    }
 
     /**
      * Destroys the component.

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -1,4 +1,4 @@
-import { ColorSource, Ticker, utils, Point, Rectangle } from '@pixi/core';
+import { ColorSource, Ticker, utils, Point } from '@pixi/core';
 import { Container, DisplayObject, IDestroyOptions } from '@pixi/display';
 import { EventMode, FederatedPointerEvent } from '@pixi/events';
 import { Graphics } from '@pixi/graphics';
@@ -19,6 +19,7 @@ export type ScrollBoxOptions = {
     globalScroll?: boolean;
     shiftScroll?: boolean;
     proximityRange?: number;
+    disableProximityCheck?: boolean;
 } & Omit<ListOptions, 'children'>;
 
 type ProximityEventData = {
@@ -26,9 +27,6 @@ type ProximityEventData = {
     index: number;
     inRange: boolean;
 };
-
-const scrollerBounds = new Rectangle();
-const itemBounds = new Rectangle();
 
 /**
  * Scrollable view, for arranging lists of Pixi container-based elements.
@@ -80,7 +78,7 @@ export class ScrollBox extends Container
     protected isOver = false;
 
     protected proximityRange: number;
-    protected proximityCache: boolean[] = [];
+    protected proximityStatusCache: boolean[] = [];
     private lastScrollX!: number | null;
     private lastScrollY!: number | null;
     public onProximityChange = new Signal<(data: ProximityEventData) => void>();
@@ -198,7 +196,7 @@ export class ScrollBox extends Container
     /** Remove all items from a scrollable list. */
     removeItems()
     {
-        this.proximityCache.length = 0;
+        this.proximityStatusCache.length = 0;
         this.list.removeChildren();
     }
 
@@ -224,7 +222,7 @@ export class ScrollBox extends Container
             child.eventMode = 'static';
 
             this.list.addChild(child);
-            this.proximityCache.push(false);
+            this.proximityStatusCache.push(false);
 
             if (!this.options.disableDynamicRendering)
             {
@@ -244,15 +242,16 @@ export class ScrollBox extends Container
     removeItem(itemID: number)
     {
         this.list.removeItem(itemID);
-        this.proximityCache.splice(itemID, 1);
+        this.proximityStatusCache.splice(itemID, 1);
         this.resize();
     }
 
     /**
      * Checks if the item is visible or scrolled out of the visible part of the view.* Adds an item to a scrollable list.
      * @param {Container} item - item to check.
+     * @param padding - proximity padding to consider the item visible.
      */
-    isItemVisible(item: Container): boolean
+    isItemVisible(item: Container, padding = 0): boolean
     {
         const isVertical = this.options.type === 'vertical' || !this.options.type;
         let isVisible = false;
@@ -262,10 +261,7 @@ export class ScrollBox extends Container
         {
             const posY = item.y + list.y;
 
-            if (
-                posY + item.height + this.list.bottomPadding >= 0
-                && posY - this.list.topPadding <= this.options.height
-            )
+            if (posY + item.height >= -padding && posY <= this.options.height + padding)
             {
                 isVisible = true;
             }
@@ -274,7 +270,7 @@ export class ScrollBox extends Container
         {
             const posX = item.x + list.x;
 
-            if (posX + item.width >= 0 && posX <= this.options.width)
+            if (posX + item.width >= -padding && posX <= this.options.width + padding)
             {
                 isVisible = true;
             }
@@ -755,43 +751,28 @@ export class ScrollBox extends Container
             this.list[type] = this._trackpad[type];
         }
 
-        if (this._trackpad.x !== this.lastScrollX || this._trackpad.y !== this.lastScrollY)
+        if (!this.options.disableProximityCheck && (
+            this._trackpad.x !== this.lastScrollX || this._trackpad.y !== this.lastScrollY
+        ))
         {
             /**
              * Wait a frame to ensure that the transforms of the scene graph are up-to-date.
              * Since we are skipping this step on the 'getBounds' calls for performance's sake,
              * this is necessary to ensure that the bounds are accurate.
              */
-            requestAnimationFrame(() => this.items.forEach((item, index) => this.checkItemProximity(item, index)));
+            requestAnimationFrame(() => this.items.forEach((item, index) =>
+            {
+                const inRange = this.isItemVisible(item, this.proximityRange);
+                const wasInRange = this.proximityStatusCache[index];
+
+                if (inRange !== wasInRange)
+                {
+                    this.proximityStatusCache[index] = inRange;
+                    this.onProximityChange.emit({ item, index, inRange });
+                }
+            }));
             this.lastScrollX = this._trackpad.x;
             this.lastScrollY = this._trackpad.y;
-        }
-    }
-
-    private checkItemProximity(item: Container, index: number): void
-    {
-        /** Get the item bounds, capping the width and height to at least 1 for the purposes of intersection checking. */
-        item.getBounds(true, itemBounds);
-        itemBounds.width = Math.max(itemBounds.width, 1);
-        itemBounds.height = Math.max(itemBounds.height, 1);
-
-        // Get the scroller bounds, expanding them by the defined max distance.
-        this.borderMask.getBounds(true, scrollerBounds);
-
-        scrollerBounds.x -= this.proximityRange;
-        scrollerBounds.y -= this.proximityRange;
-        scrollerBounds.width += this.proximityRange * 2;
-        scrollerBounds.height += this.proximityRange * 2;
-
-        // Check for intersection
-        const inRange = scrollerBounds.intersects(itemBounds);
-        const wasInRange = this.proximityCache[index];
-
-        // If the item's proximity state has changed, emit the event
-        if (inRange !== wasInRange)
-        {
-            this.proximityCache[index] = inRange;
-            this.onProximityChange.emit({ item, index, inRange });
         }
     }
 

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -1,10 +1,11 @@
-import { ColorSource, Ticker, utils, Point } from '@pixi/core';
+import { ColorSource, Ticker, utils, Point, Rectangle } from '@pixi/core';
 import { Container, DisplayObject, IDestroyOptions } from '@pixi/display';
 import { EventMode, FederatedPointerEvent } from '@pixi/events';
 import { Graphics } from '@pixi/graphics';
 import type { ListOptions, ListType } from './List';
 import { List } from './List';
 import { Trackpad } from './utils/trackpad/Trackpad';
+import { Signal } from 'typed-signals';
 
 export type ScrollBoxOptions = {
     width: number;
@@ -17,7 +18,17 @@ export type ScrollBoxOptions = {
     dragTrashHold?: number;
     globalScroll?: boolean;
     shiftScroll?: boolean;
+    proximityRange?: number;
 } & Omit<ListOptions, 'children'>;
+
+type ProximityEventData = {
+    item: Container;
+    index: number;
+    inRange: boolean;
+};
+
+const scrollerBounds = new Rectangle();
+const itemBounds = new Rectangle();
 
 /**
  * Scrollable view, for arranging lists of Pixi container-based elements.
@@ -67,6 +78,12 @@ export class ScrollBox extends Container
     protected onMouseScrollBinding = this.onMouseScroll.bind(this);
     protected dragStarTouchPoint: Point;
     protected isOver = false;
+
+    protected proximityRange: number;
+    protected proximityCache: boolean[] = [];
+    private lastScrollX!: number | null;
+    private lastScrollY!: number | null;
+    public onProximityChange = new Signal<(data: ProximityEventData) => void>();
 
     /**
      * @param options
@@ -119,6 +136,8 @@ export class ScrollBox extends Container
 
         this.__width = options.width | this.background.width;
         this.__height = options.height | this.background.height;
+
+        this.proximityRange = options.proximityRange ?? 0;
 
         if (!this.list)
         {
@@ -179,6 +198,7 @@ export class ScrollBox extends Container
     /** Remove all items from a scrollable list. */
     removeItems()
     {
+        this.proximityCache.length = 0;
         this.list.removeChildren();
     }
 
@@ -204,6 +224,7 @@ export class ScrollBox extends Container
             child.eventMode = 'static';
 
             this.list.addChild(child);
+            this.proximityCache.push(false);
 
             if (!this.options.disableDynamicRendering)
             {
@@ -223,7 +244,7 @@ export class ScrollBox extends Container
     removeItem(itemID: number)
     {
         this.list.removeItem(itemID);
-
+        this.proximityCache.splice(itemID, 1);
         this.resize();
     }
 
@@ -733,7 +754,46 @@ export class ScrollBox extends Container
         {
             this.list[type] = this._trackpad[type];
         }
+
+        if (this._trackpad.x !== this.lastScrollX || this._trackpad.y !== this.lastScrollY)
+        {
+            /**
+             * Wait a frame to ensure that the transforms of the scene graph are up-to-date.
+             * Since we are skipping this step on the 'getBounds' calls for performance's sake,
+             * this is necessary to ensure that the bounds are accurate.
+             */
+            requestAnimationFrame(() => this.items.forEach((item, index) => this.checkItemProximity(item, index)));
+            this.lastScrollX = this._trackpad.x;
+            this.lastScrollY = this._trackpad.y;
+        }
     }
+
+    private checkItemProximity(item: Container, index: number): void
+        {
+            /** Get the item bounds, capping the width and height to at least 1 for the purposes of intersection checking. */
+            item.getBounds(true, itemBounds);
+            itemBounds.width = Math.max(itemBounds.width, 1);
+            itemBounds.height = Math.max(itemBounds.height, 1);
+    
+            // Get the scroller bounds, expanding them by the defined max distance.
+            this.borderMask.getBounds(true, scrollerBounds);
+    
+            scrollerBounds.x -= this.proximityRange;
+            scrollerBounds.y -= this.proximityRange;
+            scrollerBounds.width += this.proximityRange * 2;
+            scrollerBounds.height += this.proximityRange * 2;
+    
+            // Check for intersection
+            const inRange = scrollerBounds.intersects(itemBounds);
+            const wasInRange = this.proximityCache[index];
+    
+            // If the item's proximity state has changed, emit the event
+            if (inRange !== wasInRange)
+            {
+                this.proximityCache[index] = inRange;
+                this.onProximityChange.emit({ item, index, inRange });
+            }
+        }
 
     /**
      * Destroys the component.

--- a/src/stories/scrollBox/ScrollBoxProximity.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxProximity.stories.ts
@@ -11,6 +11,7 @@ import type { StoryFn } from '@storybook/types';
 
 const args = {
     proximityRange: 100,
+    proximityDebounce: 10,
     width: 320,
     height: 420,
     radius: 20,
@@ -36,6 +37,7 @@ export const ProximityEvent: StoryFn = ({
     elementsHeight,
     itemsAmount,
     proximityRange,
+    proximityDebounce,
     type,
     fadeSpeed,
 }: any) =>
@@ -84,6 +86,7 @@ export const ProximityEvent: StoryFn = ({
         shiftScroll,
         type,
         proximityRange,
+        proximityDebounce,
     });
 
     scrollBox.addItems(items);

--- a/src/stories/scrollBox/ScrollBoxProximity.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxProximity.stories.ts
@@ -1,0 +1,120 @@
+import { Graphics } from '@pixi/graphics';
+import { Container } from '@pixi/display';
+import { Text } from '@pixi/text';
+import { argTypes, getDefaultArgs } from '../utils/argTypes';
+import { ScrollBox } from '../../ScrollBox';
+import { FancyButton } from '../../FancyButton';
+import { defaultTextStyle } from '../../utils/helpers/styles';
+import { action } from '@storybook/addon-actions';
+import { centerElement } from '../../utils/helpers/resize';
+import type { StoryFn } from '@storybook/types';
+
+const args = {
+    proximityRange: 100,
+    width: 320,
+    height: 420,
+    radius: 20,
+    elementsMargin: 10,
+    elementsPadding: 10,
+    elementsWidth: 300,
+    elementsHeight: 80,
+    itemsAmount: 100,
+    type: [undefined, 'vertical', 'horizontal'],
+    fadeSpeed: 0.5,
+};
+
+const items: FancyButton[] = [];
+const inRangeCache: boolean[] = [];
+
+export const ProximityEvent: StoryFn = ({
+    width,
+    height,
+    radius,
+    elementsMargin,
+    elementsPadding,
+    elementsWidth,
+    elementsHeight,
+    itemsAmount,
+    proximityRange,
+    type,
+    fadeSpeed,
+}: any) =>
+{
+    const view = new Container();
+
+    const fontColor = '#000000';
+    const backgroundColor = '#F5E3A9';
+    const disableEasing = false;
+    const globalScroll = true;
+    const shiftScroll = type === 'horizontal';
+    const onPress = action('Button pressed');
+
+    items.length = 0;
+    inRangeCache.length = 0;
+
+    for (let i = 0; i < itemsAmount; i++)
+    {
+        const button = new FancyButton({
+            defaultView: new Graphics().beginFill(0xa5e24d).drawRoundedRect(0, 0, elementsWidth, elementsHeight, radius),
+            hoverView: new Graphics().beginFill(0xfec230).drawRoundedRect(0, 0, elementsWidth, elementsHeight, radius),
+            pressedView: new Graphics().beginFill(0xfe6048).drawRoundedRect(0, 0, elementsWidth, elementsHeight, radius),
+            text: new Text(`Item ${i + 1}`, {
+                ...defaultTextStyle,
+                fill: fontColor
+            })
+        });
+
+        button.anchor.set(0);
+        button.onPress.connect(() => onPress(i + 1));
+        button.alpha = 0;
+
+        items.push(button);
+        inRangeCache.push(false);
+    }
+
+    const scrollBox = new ScrollBox({
+        background: backgroundColor,
+        elementsMargin,
+        width,
+        height,
+        radius,
+        padding: elementsPadding,
+        disableEasing,
+        globalScroll,
+        shiftScroll,
+        type,
+        proximityRange,
+    });
+
+    scrollBox.addItems(items);
+
+    // Handle on proximity change event.
+    scrollBox.onProximityChange.connect(({ index, inRange }) =>
+    {
+        inRangeCache[index] = inRange;
+    });
+
+    view.addChild(scrollBox);
+
+    return {
+        view,
+        resize: () => centerElement(view),
+        update: () =>
+        {
+            items.forEach((item, index) =>
+            {
+                const inRange = inRangeCache[index];
+
+                // Fade in/out according to whether the item is within the specified range.
+                if (inRange && item.alpha < 1) item.alpha += 0.04 * fadeSpeed;
+                else if (!inRange && item.alpha > 0) item.alpha -= 0.04 * fadeSpeed;
+            });
+        },
+    };
+};
+
+export default {
+    title: 'Components/ScrollBox/Proximity Event',
+    argTypes: argTypes(args),
+    args: getDefaultArgs(args)
+};


### PR DESCRIPTION
## Summary

- Checks and fires a proximity event when an item gets in and out of the proximity range.
- Proximity range can be customised, where 0 is where an item's bounds just touch the edge on the containing scroll box's bounds.

## Link to issues

Resolves ticket https://github.com/play-co/pixi-ui/issues/26