### PR TITLE
Fix: ScrollBox - Reset lastScrollX / lastScrollY on resize

### DIFF
--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -557,6 +557,9 @@ export class ScrollBox extends Container
             this._dimensionChanged = false;
         }
         else this.updateVisibleItems();
+
+        this.lastScrollX = null;
+        this.lastScrollY = null;
     }
 
     protected onMouseScroll(event: WheelEvent): void


### PR DESCRIPTION
## Summary

The `lastScrollX` and `lastScrollY` values should be reset to `null` on `resize` (which also gets triggered when adding/removing items) to allow the redo of the proximity check.