### PR TITLE
fix: Interactivity for sliders outside bounds

### DIFF
--- a/src/SliderBase.ts
+++ b/src/SliderBase.ts
@@ -178,7 +178,6 @@ export class SliderBase extends ProgressBar
         };
 
         slider.eventMode = 'static';
-        slider.x = slider.width / 2;
         slider.on('pointerdown', onPointerDown)
             .on('pointerup', this.endUpdate, this)
             .on('pointerupoutside', this.endUpdate, this);

--- a/src/SliderBase.ts
+++ b/src/SliderBase.ts
@@ -204,7 +204,9 @@ export class SliderBase extends ProgressBar
     {
         this.dragging = 1;
 
-        this.startX = this.bg.parent.worldTransform.applyInverse(event.global).x;
+        const obj = event.currentTarget as DragObject;
+
+        this.startX = obj.parent.worldTransform.applyInverse(event.global).x;
 
         this.startUpdateValue1 = this._value1;
         this.startUpdateValue2 = this._value2;

--- a/src/SliderBase.ts
+++ b/src/SliderBase.ts
@@ -167,8 +167,21 @@ export class SliderBase extends ProgressBar
     protected createSlider(sliderData: Container | string): Container
     {
         const slider = getView(sliderData);
+        const onPointerDown = (event: FederatedPointerEvent) =>
+        {
+            // This is needed to do proper calculations in update method calls
+            if (this.bg)
+            {
+                event.currentTarget = this.bg;
+            }
+            this.startUpdate(event);
+        };
 
-        slider.eventMode = 'none';
+        slider.eventMode = 'static';
+        slider.x = slider.width / 2;
+        slider.on('pointerdown', onPointerDown)
+            .on('pointerup', this.endUpdate, this)
+            .on('pointerupoutside', this.endUpdate, this);
         slider.x = slider.width / 2;
 
         const container = new Container();
@@ -191,9 +204,7 @@ export class SliderBase extends ProgressBar
     {
         this.dragging = 1;
 
-        const obj = event.currentTarget as DragObject;
-
-        this.startX = obj.parent.worldTransform.applyInverse(event.global).x;
+        this.startX = this.bg.parent.worldTransform.applyInverse(event.global).x;
 
         this.startUpdateValue1 = this._value1;
         this.startUpdateValue2 = this._value2;


### PR DESCRIPTION
This PR fixes a problem with sliders not being interactive outside bounds.

In the screenshot below, half of the slider cannot be dragged by user because it's outside view bounds.
![image](https://github.com/pixijs/ui/assets/55595100/0f2bac05-6b93-41f5-81d8-87fda33b7713)


Adding events to slider itself will take care of the problem and improve UX.
My approach is probably not very ideal but I still hope we manage to solve this somehow.

Probably fixes the problem that still persists in #136 