### PR TITLE
fix: setSize not being overridden

### DIFF
--- a/src/DoubleSlider.ts
+++ b/src/DoubleSlider.ts
@@ -1,4 +1,4 @@
-import { Container, FederatedPointerEvent } from 'pixi.js';
+import { Container, FederatedPointerEvent, Optional, Size } from 'pixi.js';
 import { Signal } from 'typed-signals';
 import { DoubleSliderOptions, SliderBase } from './SliderBase';
 
@@ -306,5 +306,13 @@ export class DoubleSlider extends SliderBase
     override get height(): number
     {
         return super.height;
+    }
+
+    override setSize(value: number | Optional<Size, 'height'>, height?: number): void
+    {
+        super.setSize(value, height);
+
+        this.updateSlider1();
+        this.updateSlider2();
     }
 }

--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -6,7 +6,7 @@ import { fitToView } from './utils/helpers/fit';
 import { AnyText, getTextView, PixiText } from './utils/helpers/text';
 import { getView } from './utils/helpers/view';
 
-import type { Sprite } from 'pixi.js';
+import type { Optional, Size, Sprite } from 'pixi.js';
 
 type State = 'default' | 'hover' | 'pressed' | 'disabled';
 type Pos = { x?: number; y?: number };
@@ -1043,5 +1043,36 @@ export class FancyButton extends ButtonContainer
     override get height(): number
     {
         return super.height;
+    }
+
+    override setSize(value: number | Optional<Size, 'height'>, height?: number): void
+    {
+        if (this.options?.nineSliceSprite)
+        {
+            if (this._views.defaultView)
+            {
+                this._views.defaultView.setSize(value, height);
+            }
+            if (this._views.hoverView)
+            {
+                this._views.hoverView.setSize(value, height);
+            }
+            if (this._views.pressedView)
+            {
+                this._views.pressedView.setSize(value, height);
+            }
+            if (this._views.disabledView)
+            {
+                this._views.disabledView.setSize(value, height);
+            }
+
+            this.adjustTextView(this.state);
+            this.adjustIconView(this.state);
+            this.updateAnchor();
+        }
+        else
+        {
+            super.setSize(value, height);
+        }
     }
 }

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -5,6 +5,8 @@ import {
     Graphics,
     isMobile,
     NineSliceSprite,
+    Optional,
+    Size,
     Sprite,
     Text,
     TextStyleOptions,
@@ -651,5 +653,41 @@ export class Input extends Container
     override get height(): number
     {
         return super.height;
+    }
+
+    override setSize(value: number | Optional<Size, 'height'>, height?: number): void
+    {
+        if (this.options?.nineSliceSprite)
+        {
+            if (this._bg)
+            {
+                this._bg.setSize(value, height);
+            }
+
+            if (this.inputMask)
+            {
+                if (typeof value === 'object')
+                {
+                    height = value.height ?? value.width;
+                    value = value.width;
+                }
+                else
+                {
+                    height = height ?? value;
+                }
+
+                this.inputMask.setSize(
+                    value - this.paddingLeft - this.paddingRight,
+                    height - this.paddingTop - this.paddingBottom
+                );
+                this.inputMask.position.set(this.paddingLeft, this.paddingTop);
+            }
+
+            this.align();
+        }
+        else
+        {
+            super.setSize(value, height);
+        }
     }
 }

--- a/src/ProgressBar.ts
+++ b/src/ProgressBar.ts
@@ -1,4 +1,4 @@
-import { Container, Graphics, NineSliceSprite as PixiNineSliceSprite, Sprite, Texture } from 'pixi.js';
+import { Container, Graphics, NineSliceSprite as PixiNineSliceSprite, Optional, Size, Sprite, Texture } from 'pixi.js';
 import { getSpriteView } from './utils/helpers/view';
 
 type FillPaddings = {
@@ -333,5 +333,43 @@ export class ProgressBar extends Container
     override get height(): number
     {
         return super.height;
+    }
+
+    override setSize(value: number | Optional<Size, 'height'>, height?: number): void
+    {
+        if (this.options?.nineSliceSprite)
+        {
+            if (this.bg)
+            {
+                this.bg.setSize(value, height);
+            }
+
+            if (this.fill)
+            {
+                if (typeof value === 'object')
+                {
+                    height = value.height ?? value.width;
+                    value = value.width;
+                }
+                else
+                {
+                    height = height ?? value;
+                }
+
+                const topPadding = this.options.fillPaddings?.top ?? 0;
+                const bottomPadding = this.options.fillPaddings?.bottom ?? 0;
+                const leftPadding = this.options.fillPaddings?.left ?? 0;
+                const rightPadding = this.options.fillPaddings?.right ?? 0;
+
+                this.fill.setSize(value - leftPadding - rightPadding, height - topPadding - bottomPadding);
+                this.fillMask.setSize(value - leftPadding - rightPadding, height - topPadding - bottomPadding);
+            }
+
+            this.progress = this._progress;
+        }
+        else
+        {
+            super.setSize(value, height);
+        }
     }
 }

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -6,8 +6,10 @@ import {
     FederatedPointerEvent,
     Graphics,
     isMobile,
+    Optional,
     Point,
     PointData,
+    Size,
     Ticker,
 } from 'pixi.js';
 import { Signal } from 'typed-signals';
@@ -770,6 +772,34 @@ export class ScrollBox extends Container
         this._dimensionChanged = true;
         this.resize();
         this.scrollTop();
+    }
+
+    override setSize(value: number | Optional<Size, 'height'>, height?: number): void
+    {
+        if (typeof value === 'object')
+        {
+            height = value.height ?? value.width;
+            value = value.width;
+        }
+        else
+        {
+            height = height ?? value;
+        }
+
+        this.__width = value;
+        this.__height = height;
+        this._dimensionChanged = true;
+        this.resize();
+        this.scrollTop();
+    }
+
+    override getSize(out?: Size): Size
+    {
+        out = out || { width: 0, height: 0 };
+        out.width = this.__width;
+        out.height = this.__height;
+
+        return out;
     }
 
     /** Gets the current raw scroll position on the x-axis (Negated Value). */

--- a/src/Slider.ts
+++ b/src/Slider.ts
@@ -1,4 +1,4 @@
-import { Container, FederatedPointerEvent } from 'pixi.js';
+import { Container, FederatedPointerEvent, Optional, Size } from 'pixi.js';
 import { Signal } from 'typed-signals';
 import { BaseSliderOptions, SliderBase } from './SliderBase';
 
@@ -190,5 +190,11 @@ export class Slider extends SliderBase
     override get height(): number
     {
         return super.height;
+    }
+
+    override setSize(value: number | Optional<Size, 'height'>, height?: number): void
+    {
+        super.setSize(value, height);
+        this.updateSlider();
     }
 }


### PR DESCRIPTION
in pixi v8 there is the get/set size functions that allow you to set both the width and height at the same time which is a bit more optimised than setting them individually

This PR ensure that any ui element that overrides width/height also overrides get/set size to ensure it works as expected