### PR TITLE
types: Updated List to accept generic types like Container

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "jest": "^26.6.3",
                 "jest-raw-loader": "^1.0.1",
                 "lint-staged": "^13.3.0",
-                "pixi.js": "^8.0.2",
+                "pixi.js": "^8.3.3",
                 "storybook": "7.6.17",
                 "typescript": "^5.4.2"
             },
@@ -27239,9 +27239,9 @@
             }
         },
         "node_modules/pixi.js": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.0.2.tgz",
-            "integrity": "sha512-E4oHF+cIkHB1BUHka8jKRih3ywDAKt/uRaTNIm4+7rEWMX5LhZZVryp8bcx516ZyQ8VrpBOs5ohrEViqYhCDAw==",
+            "version": "8.3.3",
+            "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.3.3.tgz",
+            "integrity": "sha512-dpucBKAqEm0K51MQKlXvyIJ40bcxniP82uz4ZPEQejGtPp0P+vueuG5DyArHCkC48mkVE2FEDvyYvBa45/JlQg==",
             "dev": true,
             "dependencies": {
                 "@pixi/colord": "^2.9.6",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
         "jest-raw-loader": "^1.0.1",
         "lint-staged": "^13.3.0",
         "storybook": "7.6.17",
-        "pixi.js": "^8.0.2",
+        "pixi.js": "^8.3.3",
         "typescript": "^5.4.2"
     },
     "publishConfig": {

--- a/src/List.ts
+++ b/src/List.ts
@@ -1,10 +1,10 @@
-import { Container } from 'pixi.js';
+import { Container, ContainerChild } from 'pixi.js';
 
 export type ListType = 'horizontal' | 'vertical';
 
-export type ListOptions = {
+export type ListOptions<C extends ContainerChild = ContainerChild> = {
     elementsMargin?: number;
-    children?: Container[];
+    children?: C[];
     padding?: number;
     vertPadding?: number;
     horPadding?: number;
@@ -12,7 +12,7 @@ export type ListOptions = {
     bottomPadding?: number;
     leftPadding?: number;
     rightPadding?: number;
-    items?: Container[];
+    items?: C[];
 };
 
 /**
@@ -34,9 +34,9 @@ export type ListOptions = {
  *
  * list.addChild(new Graphics().rect(0, 0, 50, 50)).fill(0x000000);
  */
-export class List extends Container
+export class List<C extends ContainerChild = ContainerChild> extends Container<C>
 {
-    protected options?: { type?: ListType } & ListOptions;
+    protected options?: { type?: ListType } & ListOptions<C>;
 
     /** Container, that holds all inner elements. */
     view: Container;
@@ -45,9 +45,9 @@ export class List extends Container
     protected _type: ListType;
 
     /** Returns all arranged elements. */
-    override readonly children: Container[] = [];
+    override readonly children: C[] = [];
 
-    constructor(options?: { type?: ListType } & ListOptions)
+    constructor(options?: { type?: ListType } & ListOptions<C>)
     {
         super();
 
@@ -66,7 +66,7 @@ export class List extends Container
      * Initiates list component.
      * @param options
      */
-    init(options?: { type?: ListType } & ListOptions)
+    init(options?: { type?: ListType } & ListOptions<C>)
     {
         this.options = options;
 


### PR DESCRIPTION
This PR adds generic types to `List` in order to behave just like `Container` in later versions of pixi.js v8.
Pixi dependency was updated intentionally as Container did not accept generic types in pixi.js v8.0.x.