### PR TITLE
Allow Texture as the View Options

### DIFF
--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -16,7 +16,7 @@ export type Offset = Pos & PosList;
 
 type ButtonViewType = 'defaultView' | 'hoverView' | 'pressedView' | 'disabledView';
 
-type ButtonView = string | Container;
+type ButtonView = string | Texture | Container;
 
 type BasicButtonViews = {
     [K in ButtonViewType]?: Container | NineSliceSprite;
@@ -578,7 +578,7 @@ export class FancyButton extends ButtonContainer
     /**
      * Helper method to update or cleanup button views.
      * @param { 'defaultView' | 'hoverView' | 'pressedView' | 'disabledView' } viewType - type of the view to update
-     * @param { string | Container | null } view - new view
+     * @param { string | Texture | Container | null } view - new view
      */
     protected updateView(viewType: ButtonViewType, view: ButtonView | null)
     {
@@ -597,6 +597,16 @@ export class FancyButton extends ButtonContainer
             {
                 this._views[viewType] = new NineSliceSprite({
                     texture: Texture.from(view),
+                    leftWidth: this.options.nineSliceSprite[0],
+                    topHeight: this.options.nineSliceSprite[1],
+                    rightWidth: this.options.nineSliceSprite[2],
+                    bottomHeight: this.options.nineSliceSprite[3],
+                });
+            }
+            else if (view instanceof Texture)
+            {
+                this._views[viewType] = new NineSliceSprite({
+                    texture: view,
                     leftWidth: this.options.nineSliceSprite[0],
                     topHeight: this.options.nineSliceSprite[1],
                     rightWidth: this.options.nineSliceSprite[2],
@@ -680,7 +690,7 @@ export class FancyButton extends ButtonContainer
 
     /**
      * Sets the iconView of the button.
-     * @param { string | Container } view - string (path to the image) or a Container-based view
+     * @param { string | Texture | Container } view - string (path to the image), texture instance or a Container-based view
      */
     set iconView(view: ButtonView | null)
     {

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -18,7 +18,7 @@ import { PixiText, PixiTextClass, PixiTextStyle } from './utils/helpers/text';
 import { getView } from './utils/helpers/view';
 import { Padding } from './utils/HelpTypes';
 
-type ViewType = Sprite | Graphics | string;
+type ViewType = Sprite | Graphics | Texture | string;
 
 export type InputOptions = {
     bg: ViewType;
@@ -89,7 +89,7 @@ export class Input extends Container
     /**
      * Creates an input.
      * @param { number } options - Options object to use.
-     * @param { Sprite | Graphics | string } options.bg - Background of the Input.
+     * @param { Sprite | Graphics | Texture | string } options.bg - Background of the Input.
      * @param { PixiTextStyle } options.textStyle - Text style of the Input.
      * @param { string } options.placeholder - Placeholder of the Input.
      * @param { string } options.value - Value of the Input.
@@ -222,6 +222,16 @@ export class Input extends Container
             {
                 this._bg = new NineSliceSprite({
                     texture: Texture.from(bg),
+                    leftWidth: this.options.nineSliceSprite[0],
+                    topHeight: this.options.nineSliceSprite[1],
+                    rightWidth: this.options.nineSliceSprite[2],
+                    bottomHeight: this.options.nineSliceSprite[3],
+                });
+            }
+            else if (bg instanceof Texture)
+            {
+                this._bg = new NineSliceSprite({
+                    texture: bg,
                     leftWidth: this.options.nineSliceSprite[0],
                     topHeight: this.options.nineSliceSprite[1],
                     rightWidth: this.options.nineSliceSprite[2],

--- a/src/ProgressBar.ts
+++ b/src/ProgressBar.ts
@@ -8,7 +8,7 @@ type FillPaddings = {
     left?: number;
 };
 
-export type ProgressBarViewType = Sprite | Graphics | string;
+export type ProgressBarViewType = Sprite | Graphics | Texture | string;
 export type NineSliceSprite = {
     bg: [number, number, number, number],
     fill: [number, number, number, number]
@@ -50,8 +50,8 @@ export class ProgressBar extends Container
     /**
      * Creates a ProgressBar.
      * @param options - Options.
-     * @param { Sprite | Graphics | string } options.bg - Background of the ProgressBar.
-     * @param { Sprite | Graphics | string } options.fill - Fill of the ProgressBar.
+     * @param { Sprite | Graphics | Texture | string } options.bg - Background of the ProgressBar.
+     * @param { Sprite | Graphics | Texture | string } options.fill - Fill of the ProgressBar.
      * @param { FillPaddings } options.fillPaddings - Fill offsets.
      * @param { number } options.fillPaddings.top - Fill top offset.
      * @param { number } options.fillPaddings.right - Fill right offset.
@@ -117,6 +117,16 @@ export class ProgressBar extends Container
                     bottomHeight: this.options.nineSliceSprite.bg[3],
                 });
             }
+            else if (bg instanceof Texture)
+            {
+                this.bg = new PixiNineSliceSprite({
+                    texture: bg,
+                    leftWidth: this.options.nineSliceSprite.bg[0],
+                    topHeight: this.options.nineSliceSprite.bg[1],
+                    rightWidth: this.options.nineSliceSprite.bg[2],
+                    bottomHeight: this.options.nineSliceSprite.bg[3],
+                });
+            }
             else
             {
                 console.warn('NineSliceSprite can not be used with views set as Container.');
@@ -162,6 +172,16 @@ export class ProgressBar extends Container
             {
                 this.fill = new PixiNineSliceSprite({
                     texture: Texture.from(fill),
+                    leftWidth: this.options.nineSliceSprite.fill[0],
+                    topHeight: this.options.nineSliceSprite.fill[1],
+                    rightWidth: this.options.nineSliceSprite.fill[2],
+                    bottomHeight: this.options.nineSliceSprite.fill[3],
+                });
+            }
+            else if (fill instanceof Texture)
+            {
+                this.fill = new PixiNineSliceSprite({
+                    texture: fill,
                     leftWidth: this.options.nineSliceSprite.fill[0],
                     topHeight: this.options.nineSliceSprite.fill[1],
                     rightWidth: this.options.nineSliceSprite.fill[2],

--- a/src/utils/helpers/view.ts
+++ b/src/utils/helpers/view.ts
@@ -1,20 +1,30 @@
-import { Container, Sprite } from 'pixi.js';
+import { Container, Sprite, Texture } from 'pixi.js';
 
-export function getView(view: string | Container): Container
+export function getView(view: string | Texture | Container): Container
 {
     if (typeof view === 'string')
     {
         return Sprite.from(view);
     }
 
+    if (view instanceof Texture)
+    {
+        return new Sprite(view);
+    }
+
     return view;
 }
 
-export function getSpriteView(view: string | Sprite): Sprite
+export function getSpriteView(view: string | Texture | Sprite): Sprite
 {
     if (typeof view === 'string')
     {
         return Sprite.from(view);
+    }
+
+    if (view instanceof Texture)
+    {
+        return new Sprite(view);
     }
 
     return view;


### PR DESCRIPTION
Allow Texture instances to be supplied as an option for:
- `FancyButton` views
- `ProgressBar` background and fill
- `Input` background