### PR TITLE
fix(Input): Use default fill color as a color source if not set

### DIFF
--- a/src/Input.ts
+++ b/src/Input.ts
@@ -176,7 +176,6 @@ export class Input extends Container
         }
         else if (key.length === 1)
         {
-
             this._add(key);
         }
         else if (this.lastInputData && this.lastInputData.length === 1)
@@ -200,9 +199,10 @@ export class Input extends Container
 
         this.options.textStyle = options.textStyle ?? defaultTextStyle;
         this.options.TextClass = options.TextClass ?? Text;
+
         const textStyle = { ...defaultTextStyle, ...options.textStyle };
-        const colorSource = Color.isColorLike(this.options.textStyle.fill)
-            ? this.options.textStyle.fill
+        const colorSource = Color.isColorLike(textStyle.fill)
+            ? textStyle.fill
             : 0x000000;
 
         this.inputField = new this.options.TextClass({

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -201,7 +201,7 @@ export class Input extends Container
         this.options.TextClass = options.TextClass ?? Text;
 
         const textStyle = { ...defaultTextStyle, ...options.textStyle };
-        const colorSource = Color.isColorLike(textStyle.fill)
+        const colorSource = textStyle.fill && Color.isColorLike(textStyle.fill)
             ? textStyle.fill
             : 0x000000;
 


### PR DESCRIPTION
This PR adds a missing check in case text fill is null or undefined.
Essentially, it prevents `Color.isColorLike` from throwing and PR is not needed in v1 since we have a different approach there.