### PR TITLE
Add the ability for the scrollbox to scroll in both direction

### DIFF
--- a/src/Input.ts
+++ b/src/Input.ts
@@ -183,7 +183,8 @@ export class Input extends Container
             this._add(this.lastInputData);
         }
 
-        if (this.input) {
+        if (this.input)
+        {
             this.input.value = '';
         }
     }
@@ -720,10 +721,11 @@ export class Input extends Container
         this.inputMask.position.set(this.paddingLeft, this.paddingTop);
     }
 
-    protected onPaste(e: any) {
+    protected onPaste(e: any)
+    {
         e.preventDefault();
 
-        const text = (e.clipboardData || (window as any).clipboardData).getData("text");
+        const text = (e.clipboardData || (window as any).clipboardData).getData('text');
 
         if (!text) return;
 

--- a/src/List.ts
+++ b/src/List.ts
@@ -1,6 +1,7 @@
 import { Container, ContainerChild } from 'pixi.js';
+import { LIST_TYPE } from './utils/HelpTypes';
 
-export type ListType = 'horizontal' | 'vertical' | 'bidirectional';
+export type ListType = (typeof LIST_TYPE)[number];
 
 export type ListOptions<C extends ContainerChild = ContainerChild> = {
     elementsMargin?: number;
@@ -307,7 +308,7 @@ export class List<C extends ContainerChild = ContainerChild> extends Container<C
                     break;
 
                 case 'bidirectional':
-                default: // bidirectional
+                default:
                     child.x = x;
                     child.y = y;
 

--- a/src/List.ts
+++ b/src/List.ts
@@ -1,6 +1,6 @@
 import { Container, ContainerChild } from 'pixi.js';
 
-export type ListType = 'horizontal' | 'vertical';
+export type ListType = 'horizontal' | 'vertical' | 'bidirectional';
 
 export type ListOptions<C extends ContainerChild = ContainerChild> = {
     elementsMargin?: number;
@@ -306,6 +306,7 @@ export class List<C extends ContainerChild = ContainerChild> extends Container<C
                     x += elementsMargin + child.width;
                     break;
 
+                case 'bidirectional':
                 default: // bidirectional
                     child.x = x;
                     child.y = y;

--- a/src/List.ts
+++ b/src/List.ts
@@ -14,6 +14,8 @@ export type ListOptions<C extends ContainerChild = ContainerChild> = {
     leftPadding?: number;
     rightPadding?: number;
     items?: C[];
+    maxWidth?: number;
+    maxHeight?: number;
 };
 
 /**
@@ -23,6 +25,9 @@ export type ListOptions<C extends ContainerChild = ContainerChild> = {
  *
  * If type is not specified, it will be acting like a bidirectional, items will be arranged to fit horizontally,
  * after there is no space left, new line will be started, so items will be arranged like `inline-block` in css.
+ * Max width to fit horizontally can be set by `maxWidth` option, of not set, parent width will be used.
+ * Check this example to see how it works:
+ * https://pixijs.io/ui/storybook/?path=/story/components-scrollbox-use-graphics--use-graphics
  *
  * It is used inside elements with repeatable content, like {@link Select} or {@link ScrollBox}.
  * @example
@@ -45,6 +50,9 @@ export class List<C extends ContainerChild = ContainerChild> extends Container<C
     /** Arrange direction. */
     protected _type: ListType;
 
+    /** Width of area to fit elements when arrange. (If not set parent width will be used). */
+    protected _maxWidth: number;
+
     /** Returns all arranged elements. */
     override readonly children: C[] = [];
 
@@ -54,8 +62,13 @@ export class List<C extends ContainerChild = ContainerChild> extends Container<C
 
         if (options)
         {
+            if (options.maxWidth) {
+                this._maxWidth = options.maxWidth;
+            }
+
             this.init(options);
         }
+
 
         options?.items?.forEach((item) => this.addChild(item));
 
@@ -282,7 +295,7 @@ export class List<C extends ContainerChild = ContainerChild> extends Container<C
         let y = this.topPadding;
 
         const elementsMargin = this.options?.elementsMargin ?? 0;
-        let maxWidth = this.parent?.width;
+        let maxWidth = this.maxWidth ?? this.parent?.width;
 
         if (this.rightPadding)
         {
@@ -344,5 +357,20 @@ export class List<C extends ContainerChild = ContainerChild> extends Container<C
 
         this.removeChild(child);
         this.arrangeChildren();
+    }
+
+    /**
+     * Set width of area to fit elements when arrange. (If not set parent width will be used).
+     */
+    set maxWidth(width: number) {
+        this._maxWidth = width;
+        this.arrangeChildren();
+    }
+
+    /**
+     * Get width of area to fit elements when arrange. (If not set parent width will be used).
+     */
+    get maxWidth(): number {
+        return this._maxWidth;
     }
 }

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -97,23 +97,6 @@ export class ScrollBox extends Container
     public onProximityChange = new Signal<(data: ProximityEventData) => void>();
     public onScroll: Signal<(value: number | PointData) => void> = new Signal();
 
-    protected get isVertical(): boolean
-    {
-        return this.options.type === 'vertical';
-    }
-
-    protected get isHorizontal(): boolean
-    {
-        return this.options.type === 'horizontal';
-    }
-
-    protected get isBidirectional(): boolean
-    {
-        const type = this.options.type ?? 'bidirectional';
-
-        return type === 'bidirectional';
-    }
-
     /**
      * @param options
      * @param {number} options.background - background color of the ScrollBox.
@@ -950,4 +933,22 @@ export class ScrollBox extends Container
     {
         return this.list.width;
     }
+
+    protected get isVertical(): boolean
+    {
+        return this.options.type === 'vertical';
+    }
+
+    protected get isHorizontal(): boolean
+    {
+        return this.options.type === 'horizontal';
+    }
+
+    protected get isBidirectional(): boolean
+    {
+        const type = this.options.type ?? 'bidirectional';
+
+        return type === 'bidirectional';
+    }
+
 }

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -68,11 +68,15 @@ export class ScrollBox extends Container
     protected borderMask: Graphics;
     protected lastWidth: number;
     protected lastHeight: number;
-    protected __width = 0;
-    protected __height = 0;
+    protected _width = 0;
+    protected _height = 0;
     protected _dimensionChanged = false;
 
-    protected list: List;
+    /**
+     * Arrange container, that holds all inner elements.
+     * Use this control inner arrange container size in case of bidirectional scroll type.
+     */
+    list: List;
 
     protected _trackpad: Trackpad;
     protected isDragging = 0;
@@ -146,8 +150,8 @@ export class ScrollBox extends Container
         this.options = options;
         this.setBackground(options.background);
 
-        this.__width = options.width | this.background.width;
-        this.__height = options.height | this.background.height;
+        this._width = options.width | this.background.width;
+        this._height = options.height | this.background.height;
 
         this.proximityRange = options.proximityRange ?? 0;
 
@@ -188,7 +192,7 @@ export class ScrollBox extends Container
 
     protected get hasBounds(): boolean
     {
-        return !!this.__width || !!this.__height;
+        return !!this._width || !!this._height;
     }
 
     /**
@@ -484,17 +488,17 @@ export class ScrollBox extends Container
         {
             if (!this.options.width)
             {
-                this.__width += this.listWidth;
+                this._width += this.listWidth;
             }
 
             if (!this.options.height)
             {
-                this.__height += this.listHeight;
+                this._height += this.listHeight;
             }
 
             this.borderMask
                 .clear()
-                .roundRect(0, 0, this.__width, this.__height, this.options.radius | 0)
+                .roundRect(0, 0, this._width, this._height, this.options.radius | 0)
                 .fill(0xff00ff)
                 .stroke(0x0);
             this.borderMask.eventMode = 'none';
@@ -503,7 +507,7 @@ export class ScrollBox extends Container
 
             this.background
                 .clear()
-                .roundRect(0, 0, this.__width, this.__height, this.options.radius | 0)
+                .roundRect(0, 0, this._width, this._height, this.options.radius | 0)
                 .fill({
                     color: color ?? 0x000000,
                     alpha: color ? 1 : 0.0000001, // if color is not set, set alpha to 0 to be able to drag by click on bg
@@ -511,15 +515,15 @@ export class ScrollBox extends Container
 
             if (this.isBidirectional)
             {
-                this.setInteractive(this.listWidth > this.__width || this.listHeight > this.__height);
+                this.setInteractive(this.listWidth > this._width || this.listHeight > this._height);
             }
             else if (this.isHorizontal)
             {
-                this.setInteractive(this.listWidth > this.__width);
+                this.setInteractive(this.listWidth > this._width);
             }
             else
             {
-                this.setInteractive(this.listHeight > this.__height);
+                this.setInteractive(this.listHeight > this._height);
             }
 
             this.lastWidth = this.listWidth;
@@ -588,13 +592,13 @@ export class ScrollBox extends Container
             const delta = shiftScroll || this.isBidirectional ? event.deltaX : event.deltaY;
             const targetPos = this.list.x - delta;
 
-            if (this.listWidth < this.__width)
+            if (this.listWidth < this._width)
             {
                 this._trackpad.xAxis.value = 0;
             }
             else
             {
-                const min = this.__width - this.listWidth;
+                const min = this._width - this.listWidth;
                 const max = 0;
 
                 this._trackpad.xAxis.value = Math.min(max, Math.max(min, targetPos));
@@ -605,13 +609,13 @@ export class ScrollBox extends Container
         {
             const targetPos = this.list.y - event.deltaY;
 
-            if (this.listHeight < this.__height)
+            if (this.listHeight < this._height)
             {
                 this._trackpad.yAxis.value = 0;
             }
             else
             {
-                const min = this.__height - this.listHeight;
+                const min = this._height - this.listHeight;
                 const max = 0;
 
                 this._trackpad.yAxis.value = Math.min(max, Math.max(min, targetPos));
@@ -722,12 +726,12 @@ export class ScrollBox extends Container
 
         this._trackpad.xAxis.value
             = this.isHorizontal || this.isBidirectional
-                ? this.__width - target.x - target.width - this.list.rightPadding
+                ? this._width - target.x - target.width - this.list.rightPadding
                 : 0;
 
         this._trackpad.yAxis.value
             = this.isVertical || this.isBidirectional
-                ? this.__height - target.y - target.height - this.list.bottomPadding
+                ? this._height - target.y - target.height - this.list.bottomPadding
                 : 0;
 
         this.stopRenderHiddenItems();
@@ -751,12 +755,12 @@ export class ScrollBox extends Container
     /** Gets component height. */
     override get height(): number
     {
-        return this.__height;
+        return this._height;
     }
 
     override set height(value: number)
     {
-        this.__height = value;
+        this._height = value;
         this._dimensionChanged = true;
         this.resize();
         this.scrollTop();
@@ -765,12 +769,12 @@ export class ScrollBox extends Container
     /** Gets component width. */
     override get width(): number
     {
-        return this.__width;
+        return this._width;
     }
 
     override set width(value: number)
     {
-        this.__width = value;
+        this._width = value;
         this._dimensionChanged = true;
         this.resize();
         this.scrollTop();
@@ -788,8 +792,8 @@ export class ScrollBox extends Container
             height = height ?? value;
         }
 
-        this.__width = value;
-        this.__height = height;
+        this._width = value;
+        this._height = height;
         this._dimensionChanged = true;
         this.resize();
         this.scrollTop();
@@ -798,8 +802,8 @@ export class ScrollBox extends Container
     override getSize(out?: Size): Size
     {
         out = out || { width: 0, height: 0 };
-        out.width = this.__width;
-        out.height = this.__height;
+        out.width = this._width;
+        out.height = this._height;
 
         return out;
     }

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -29,7 +29,6 @@ export type ScrollBoxOptions = {
     dragTrashHold?: number;
     globalScroll?: boolean;
     shiftScroll?: boolean;
-    bidirectionalScroll?: boolean;
     proximityRange?: number;
     proximityDebounce?: number;
     disableProximityCheck?: boolean;
@@ -100,19 +99,19 @@ export class ScrollBox extends Container
 
     protected get isVertical(): boolean
     {
-        const type = this.options.type ?? 'vertical';
-
-        return type === 'vertical';
+        return this.options.type === 'vertical';
     }
 
     protected get isHorizontal(): boolean
     {
-        return !this.isVertical;
+        return this.options.type === 'horizontal';
     }
 
     protected get isBidirectional(): boolean
     {
-        return !!this.options.bidirectionalScroll;
+        const type = this.options.type ?? 'bidirectional';
+
+        return type === 'bidirectional';
     }
 
     /**
@@ -130,8 +129,6 @@ export class ScrollBox extends Container
      * @param {boolean} [options.globalScroll=true] - if true, the ScrollBox will scroll even if the mouse is not over it.
      * @param {boolean} [options.shiftScroll=false] - if true, the ScrollBox will only scroll horizontally if the shift key
      * is pressed, and the type is set to 'horizontal'.
-     * @param {boolean} [options.bidirectionalScroll=false] - if true, the ScrollBox will scroll both vertically and
-     * horizontally, accommodating overflows in both directions.
      */
     constructor(options?: ScrollBoxOptions)
     {

--- a/src/stories/list/ListGraphics.stories.ts
+++ b/src/stories/list/ListGraphics.stories.ts
@@ -8,7 +8,7 @@ import { argTypes, getDefaultArgs } from '../utils/argTypes';
 import { action } from '@storybook/addon-actions';
 
 const args = {
-    type: [null, 'horizontal', 'vertical'],
+    type: [null, 'horizontal', 'vertical', 'bidirectional'],
     fontColor: '#000000',
     bgColor: '#f5e3a9',
     width: 271,
@@ -24,7 +24,7 @@ const args = {
     onPress: action('Button pressed'),
 };
 
-export const UseGraphics: StoryFn<typeof args & { type: 'horizontal' | 'vertical' }> = (
+export const UseGraphics: StoryFn<typeof args & { type: 'horizontal' | 'vertical' | 'bidirectional' }> = (
     {
         type,
         fontColor,

--- a/src/stories/list/ListGraphics.stories.ts
+++ b/src/stories/list/ListGraphics.stories.ts
@@ -1,14 +1,15 @@
 import { Graphics, Text } from 'pixi.js';
 import { PixiStory, StoryFn } from '@pixi/storybook-renderer';
 import { FancyButton } from '../../FancyButton';
-import { List } from '../../List';
+import { List, ListType } from '../../List';
 import { centerElement } from '../../utils/helpers/resize';
 import { defaultTextStyle } from '../../utils/helpers/styles';
 import { argTypes, getDefaultArgs } from '../utils/argTypes';
 import { action } from '@storybook/addon-actions';
+import { LIST_TYPE } from '../../utils/HelpTypes';
 
 const args = {
-    type: [null, 'horizontal', 'vertical', 'bidirectional'],
+    type: [null, ...LIST_TYPE],
     fontColor: '#000000',
     bgColor: '#f5e3a9',
     width: 271,
@@ -24,7 +25,7 @@ const args = {
     onPress: action('Button pressed'),
 };
 
-export const UseGraphics: StoryFn<typeof args & { type: 'horizontal' | 'vertical' | 'bidirectional' }> = (
+export const UseGraphics: StoryFn<typeof args & { type:ListType }> = (
     {
         type,
         fontColor,

--- a/src/stories/list/ListSprite.stories.ts
+++ b/src/stories/list/ListSprite.stories.ts
@@ -1,23 +1,24 @@
 import { Container, Sprite, Text } from 'pixi.js';
 import { PixiStory, StoryFn } from '@pixi/storybook-renderer';
 import { FancyButton } from '../../FancyButton';
-import { List } from '../../List';
+import { List, ListType } from '../../List';
 import { centerElement } from '../../utils/helpers/resize';
 import { defaultTextStyle } from '../../utils/helpers/styles';
 import { argTypes, getDefaultArgs } from '../utils/argTypes';
 import { getColor } from '../utils/color';
 import { preload } from '../utils/loader';
 import { action } from '@storybook/addon-actions';
+import { LIST_TYPE } from '../../utils/HelpTypes';
 
 const args = {
-    type: [null, 'horizontal', 'vertical', 'bidirectional'],
+    type: [null, ...LIST_TYPE],
     fontColor: '#000000',
     elementsMargin: 29,
-    itemsAmount: 10,
+    itemsAmount: 12,
     onPress: action('Button pressed'),
 };
 
-export const UseSprite: StoryFn<typeof args & { type: 'horizontal' | 'vertical' | 'bidirectional' }> = (
+export const UseSprite: StoryFn<typeof args & { type:ListType }> = (
     { fontColor, elementsMargin, itemsAmount, onPress, type },
     context,
 ) =>

--- a/src/stories/list/ListSprite.stories.ts
+++ b/src/stories/list/ListSprite.stories.ts
@@ -10,14 +10,14 @@ import { preload } from '../utils/loader';
 import { action } from '@storybook/addon-actions';
 
 const args = {
-    type: [null, 'horizontal', 'vertical'],
+    type: [null, 'horizontal', 'vertical', 'bidirectional'],
     fontColor: '#000000',
     elementsMargin: 29,
     itemsAmount: 10,
     onPress: action('Button pressed'),
 };
 
-export const UseSprite: StoryFn<typeof args & { type: 'horizontal' | 'vertical' }> = (
+export const UseSprite: StoryFn<typeof args & { type: 'horizontal' | 'vertical' | 'bidirectional' }> = (
     { fontColor, elementsMargin, itemsAmount, onPress, type },
     context,
 ) =>

--- a/src/stories/list/ListSprite.stories.ts
+++ b/src/stories/list/ListSprite.stories.ts
@@ -11,15 +11,23 @@ import { action } from '@storybook/addon-actions';
 import { LIST_TYPE } from '../../utils/HelpTypes';
 
 const args = {
-    type: [null, ...LIST_TYPE],
+    type: LIST_TYPE.reverse(),
     fontColor: '#000000',
     elementsMargin: 29,
     itemsAmount: 12,
+    maxWidth: 500,
     onPress: action('Button pressed'),
 };
 
 export const UseSprite: StoryFn<typeof args & { type:ListType }> = (
-    { fontColor, elementsMargin, itemsAmount, onPress, type },
+    {
+        fontColor,
+        elementsMargin,
+        itemsAmount,
+        type,
+        maxWidth,
+        onPress,
+    },
     context,
 ) =>
     new PixiStory<typeof args>({
@@ -56,6 +64,7 @@ export const UseSprite: StoryFn<typeof args & { type:ListType }> = (
                     vertPadding: 70,
                     horPadding: 50,
                     elementsMargin,
+                    maxWidth,
                 });
 
                 items.forEach((item) => list.addChild(item));

--- a/src/stories/scrollBox/ScrollBoxDynamicDimensions.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxDynamicDimensions.stories.ts
@@ -5,15 +5,18 @@ import { ScrollBox } from '../../ScrollBox';
 import { centerElement } from '../../utils/helpers/resize';
 import { defaultTextStyle } from '../../utils/helpers/styles';
 import { argTypes, getDefaultArgs } from '../utils/argTypes';
+import { LIST_TYPE } from '../../utils/HelpTypes';
+import { ListType } from '../../List';
 
 const args = {
     fontColor: '#000000',
     backgroundColor: '#F5E3A9',
     itemsAmount: 100,
+    type: [...LIST_TYPE],
 };
 
-export const UseDynamicDimensions: StoryFn<typeof args> = (
-    { fontColor, itemsAmount, backgroundColor },
+export const UseDynamicDimensions: StoryFn<typeof args & { type:ListType }> = (
+    { fontColor, itemsAmount, backgroundColor, type },
     context,
 ) =>
     new PixiStory({
@@ -38,6 +41,7 @@ export const UseDynamicDimensions: StoryFn<typeof args> = (
                 width: sizes[currentSizeID].w,
                 height: sizes[currentSizeID].h,
                 radius,
+                type,
                 padding: 10,
             });
 

--- a/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
@@ -12,18 +12,19 @@ import { ListType } from '../../List';
 const args = {
     fontColor: '#000000',
     backgroundColor: '#F5E3A9',
-    width: 320,
+    width: 490,
     height: 420,
     radius: 20,
     elementsMargin: 10,
     elementsPadding: 10,
-    elementsWidth: 300,
+    elementsWidth: 150,
     elementsHeight: 80,
     itemsAmount: 100,
     disableEasing: false,
     globalScroll: true,
     shiftScroll: false,
-    type: [...LIST_TYPE],
+    type: LIST_TYPE.reverse(),
+    innerListWidth: 1000,
     onPress: action('Button pressed'),
 };
 
@@ -44,6 +45,7 @@ export const UseGraphics: StoryFn<typeof args & { type:ListType }> = (
         onPress,
         globalScroll,
         shiftScroll,
+        innerListWidth,
     },
     context,
 ) =>
@@ -93,6 +95,11 @@ export const UseGraphics: StoryFn<typeof args & { type:ListType }> = (
                 globalScroll,
                 shiftScroll,
             });
+
+            if (type === 'bidirectional')
+            {
+                scrollBox.list.maxWidth = innerListWidth;
+            }
 
             scrollBox.addItems(items);
 

--- a/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
@@ -22,6 +22,7 @@ const args = {
     globalScroll: true,
     shiftScroll: false,
     type: [undefined, 'vertical', 'horizontal'],
+    bidirectionalScroll: false,
     onPress: action('Button pressed'),
 };
 
@@ -42,6 +43,7 @@ export const UseGraphics: StoryFn<typeof args & { type: 'vertical' | 'horizontal
         onPress,
         globalScroll,
         shiftScroll,
+        bidirectionalScroll,
     },
     context,
 ) =>
@@ -90,6 +92,7 @@ export const UseGraphics: StoryFn<typeof args & { type: 'vertical' | 'horizontal
                 type,
                 globalScroll,
                 shiftScroll,
+                bidirectionalScroll,
             });
 
             scrollBox.addItems(items);

--- a/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
@@ -17,16 +17,15 @@ const args = {
     elementsPadding: 10,
     elementsWidth: 300,
     elementsHeight: 80,
-    itemsAmount: 100,
+    itemsAmount: 1,
     disableEasing: false,
     globalScroll: true,
     shiftScroll: false,
-    type: [undefined, 'vertical', 'horizontal'],
-    bidirectionalScroll: false,
+    type: [undefined, 'vertical', 'horizontal', 'bidirectional'],
     onPress: action('Button pressed'),
 };
 
-export const UseGraphics: StoryFn<typeof args & { type: 'vertical' | 'horizontal' | undefined }> = (
+export const UseGraphics: StoryFn<typeof args & { type: 'vertical' | 'horizontal' | 'bidirectional' | undefined }> = (
     {
         fontColor,
         elementsMargin,
@@ -43,7 +42,6 @@ export const UseGraphics: StoryFn<typeof args & { type: 'vertical' | 'horizontal
         onPress,
         globalScroll,
         shiftScroll,
-        bidirectionalScroll,
     },
     context,
 ) =>
@@ -92,7 +90,6 @@ export const UseGraphics: StoryFn<typeof args & { type: 'vertical' | 'horizontal
                 type,
                 globalScroll,
                 shiftScroll,
-                bidirectionalScroll,
             });
 
             scrollBox.addItems(items);

--- a/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
@@ -6,6 +6,8 @@ import { centerElement } from '../../utils/helpers/resize';
 import { defaultTextStyle } from '../../utils/helpers/styles';
 import { argTypes, getDefaultArgs } from '../utils/argTypes';
 import { action } from '@storybook/addon-actions';
+import { LIST_TYPE } from '../../utils/HelpTypes';
+import { ListType } from '../../List';
 
 const args = {
     fontColor: '#000000',
@@ -17,15 +19,15 @@ const args = {
     elementsPadding: 10,
     elementsWidth: 300,
     elementsHeight: 80,
-    itemsAmount: 1,
+    itemsAmount: 100,
     disableEasing: false,
     globalScroll: true,
     shiftScroll: false,
-    type: [undefined, 'vertical', 'horizontal', 'bidirectional'],
+    type: [...LIST_TYPE],
     onPress: action('Button pressed'),
 };
 
-export const UseGraphics: StoryFn<typeof args & { type: 'vertical' | 'horizontal' | 'bidirectional' | undefined }> = (
+export const UseGraphics: StoryFn<typeof args & { type:ListType }> = (
     {
         fontColor,
         elementsMargin,

--- a/src/stories/scrollBox/ScrollBoxProximity.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxProximity.stories.ts
@@ -18,7 +18,7 @@ const args = {
     elementsWidth: 300,
     elementsHeight: 80,
     itemsAmount: 100,
-    type: [undefined, 'vertical', 'horizontal'],
+    type: [undefined, 'vertical', 'horizontal', 'bidirectional'],
     fadeSpeed: 0.5,
 };
 
@@ -26,7 +26,7 @@ const items: FancyButton[] = [];
 const inRangeCache: boolean[] = [];
 
 export const ProximityEvent: StoryFn<
-    typeof args & { type: 'vertical' | 'horizontal' | undefined }
+    typeof args & { type: 'vertical' | 'horizontal' | 'bidirectional' | undefined }
 > = (
     {
         width,

--- a/src/stories/scrollBox/ScrollBoxProximity.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxProximity.stories.ts
@@ -6,6 +6,8 @@ import { centerElement } from '../../utils/helpers/resize';
 import { defaultTextStyle } from '../../utils/helpers/styles';
 import { argTypes, getDefaultArgs } from '../utils/argTypes';
 import { action } from '@storybook/addon-actions';
+import { ListType } from '../../List';
+import { LIST_TYPE } from '../../utils/HelpTypes';
 
 const args = {
     proximityRange: 100,
@@ -18,7 +20,7 @@ const args = {
     elementsWidth: 300,
     elementsHeight: 80,
     itemsAmount: 100,
-    type: [undefined, 'vertical', 'horizontal', 'bidirectional'],
+    type: [...LIST_TYPE],
     fadeSpeed: 0.5,
 };
 
@@ -26,7 +28,7 @@ const items: FancyButton[] = [];
 const inRangeCache: boolean[] = [];
 
 export const ProximityEvent: StoryFn<
-    typeof args & { type: 'vertical' | 'horizontal' | 'bidirectional' | undefined }
+    typeof args & { type:ListType }
 > = (
     {
         width,

--- a/src/stories/scrollBox/ScrollBoxSprite.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxSprite.stories.ts
@@ -7,19 +7,21 @@ import { defaultTextStyle } from '../../utils/helpers/styles';
 import { argTypes, getDefaultArgs } from '../utils/argTypes';
 import { preload } from '../utils/loader';
 import { action } from '@storybook/addon-actions';
+import { ListType } from '../../List';
+import { LIST_TYPE } from '../../utils/HelpTypes';
 
 const args = {
     fontColor: '#000000',
     elementsMargin: 6,
     itemsAmount: 100,
     disableEasing: false,
-    type: [undefined, 'vertical', 'horizontal', 'bidirectional'],
+    type: [...LIST_TYPE],
     onPress: action('Button pressed'),
     globalScroll: true,
     shiftScroll: false,
 };
 
-export const UseSprite: StoryFn<typeof args & { type: 'vertical' | 'horizontal' | 'bidirectional' | undefined }> = (
+export const UseSprite: StoryFn<typeof args & { type:ListType }> = (
     {
         fontColor,
         elementsMargin,

--- a/src/stories/scrollBox/ScrollBoxSprite.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxSprite.stories.ts
@@ -15,7 +15,7 @@ const args = {
     elementsMargin: 6,
     itemsAmount: 100,
     disableEasing: false,
-    type: [...LIST_TYPE],
+    type: [null, ...LIST_TYPE],
     onPress: action('Button pressed'),
     globalScroll: true,
     shiftScroll: false,
@@ -75,6 +75,12 @@ export const UseSprite: StoryFn<typeof args & { type:ListType }> = (
                     globalScroll,
                     shiftScroll,
                 });
+
+                if (type === 'bidirectional')
+                {
+                    scrollBox.list.width = window.width - 40;
+                    scrollBox.list.height = window.height - 60;
+                }
 
                 scrollBox.addItems(items);
 

--- a/src/stories/scrollBox/ScrollBoxSprite.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxSprite.stories.ts
@@ -14,6 +14,7 @@ const args = {
     itemsAmount: 100,
     disableEasing: false,
     type: [undefined, 'vertical', 'horizontal'],
+    bidirectionalScroll: false,
     onPress: action('Button pressed'),
     globalScroll: true,
     shiftScroll: false,
@@ -29,6 +30,7 @@ export const UseSprite: StoryFn<typeof args & { type: 'vertical' | 'horizontal' 
         onPress,
         globalScroll,
         shiftScroll,
+        bidirectionalScroll,
     },
     context,
 ) =>
@@ -72,6 +74,7 @@ export const UseSprite: StoryFn<typeof args & { type: 'vertical' | 'horizontal' 
                     type,
                     globalScroll,
                     shiftScroll,
+                    bidirectionalScroll,
                 });
 
                 scrollBox.addItems(items);

--- a/src/stories/scrollBox/ScrollBoxSprite.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxSprite.stories.ts
@@ -13,14 +13,13 @@ const args = {
     elementsMargin: 6,
     itemsAmount: 100,
     disableEasing: false,
-    type: [undefined, 'vertical', 'horizontal'],
-    bidirectionalScroll: false,
+    type: [undefined, 'vertical', 'horizontal', 'bidirectional'],
     onPress: action('Button pressed'),
     globalScroll: true,
     shiftScroll: false,
 };
 
-export const UseSprite: StoryFn<typeof args & { type: 'vertical' | 'horizontal' | undefined }> = (
+export const UseSprite: StoryFn<typeof args & { type: 'vertical' | 'horizontal' | 'bidirectional' | undefined }> = (
     {
         fontColor,
         elementsMargin,
@@ -30,7 +29,6 @@ export const UseSprite: StoryFn<typeof args & { type: 'vertical' | 'horizontal' 
         onPress,
         globalScroll,
         shiftScroll,
-        bidirectionalScroll,
     },
     context,
 ) =>
@@ -74,7 +72,6 @@ export const UseSprite: StoryFn<typeof args & { type: 'vertical' | 'horizontal' 
                     type,
                     globalScroll,
                     shiftScroll,
-                    bidirectionalScroll,
                 });
 
                 scrollBox.addItems(items);

--- a/src/utils/HelpTypes.ts
+++ b/src/utils/HelpTypes.ts
@@ -24,3 +24,6 @@ export type Padding =
         top?: number;
         bottom?: number;
     };
+
+export const LIST_TYPE = ['vertical', 'horizontal', 'bidirectional'];
+


### PR DESCRIPTION
Added `bidirectionalScroll` to the `ScrollBoxOptions`, which allows the scroll-box to be scrolled both vertically and horizontally to accommodate overflows in both directions. 