### PR TITLE
Hot-fix: Make ScrollBox Type Defaults to 'vertical'

### DIFF
--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -940,7 +940,9 @@ export class ScrollBox extends Container
 
     protected get isVertical(): boolean
     {
-        return this.options.type === 'vertical';
+        const type = this.options.type ?? 'vertical';
+
+        return type === 'vertical';
     }
 
     protected get isHorizontal(): boolean
@@ -950,8 +952,6 @@ export class ScrollBox extends Container
 
     protected get isBidirectional(): boolean
     {
-        const type = this.options.type ?? 'bidirectional';
-
-        return type === 'bidirectional';
+        return this.options.type === 'bidirectional';
     }
 }

--- a/src/stories/list/ListSprite.stories.ts
+++ b/src/stories/list/ListSprite.stories.ts
@@ -11,7 +11,7 @@ import { preload } from '../utils/loader';
 import { action } from '@storybook/addon-actions';
 
 const args = {
-    type: LIST_TYPE.reverse(),
+    type: LIST_TYPE,
     fontColor: '#000000',
     elementsMargin: 29,
     itemsAmount: 12,

--- a/src/stories/scrollBox/ScrollBoxDynamicDimensions.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxDynamicDimensions.stories.ts
@@ -12,7 +12,7 @@ const args = {
     fontColor: '#000000',
     backgroundColor: '#F5E3A9',
     itemsAmount: 100,
-    type: [null, ...LIST_TYPE.reverse()],
+    type: [null, ...LIST_TYPE],
 };
 
 export const UseDynamicDimensions: StoryFn<typeof args & { type: ListType }> = (

--- a/src/stories/scrollBox/ScrollBoxDynamicDimensions.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxDynamicDimensions.stories.ts
@@ -12,7 +12,7 @@ const args = {
     fontColor: '#000000',
     backgroundColor: '#F5E3A9',
     itemsAmount: 100,
-    type: [...LIST_TYPE],
+    type: [null, ...LIST_TYPE.reverse()],
 };
 
 export const UseDynamicDimensions: StoryFn<typeof args & { type: ListType }> = (

--- a/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
@@ -23,7 +23,7 @@ const args = {
     disableEasing: false,
     globalScroll: true,
     shiftScroll: false,
-    type: LIST_TYPE.reverse(),
+    type: [null, ...LIST_TYPE.reverse()],
     innerListWidth: 1000,
     onPress: action('Button pressed'),
 };

--- a/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
@@ -23,7 +23,7 @@ const args = {
     disableEasing: false,
     globalScroll: true,
     shiftScroll: false,
-    type: [null, ...LIST_TYPE.reverse()],
+    type: [null, ...LIST_TYPE],
     innerListWidth: 1000,
     onPress: action('Button pressed'),
 };

--- a/src/stories/scrollBox/ScrollBoxProximity.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxProximity.stories.ts
@@ -20,7 +20,7 @@ const args = {
     elementsWidth: 300,
     elementsHeight: 80,
     itemsAmount: 100,
-    type: [null, ...LIST_TYPE.reverse()],
+    type: [null, ...LIST_TYPE],
     fadeSpeed: 0.5,
 };
 

--- a/src/stories/scrollBox/ScrollBoxProximity.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxProximity.stories.ts
@@ -20,7 +20,7 @@ const args = {
     elementsWidth: 300,
     elementsHeight: 80,
     itemsAmount: 100,
-    type: [...LIST_TYPE],
+    type: [null, ...LIST_TYPE.reverse()],
     fadeSpeed: 0.5,
 };
 

--- a/src/stories/scrollBox/ScrollBoxSprite.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxSprite.stories.ts
@@ -15,7 +15,7 @@ const args = {
     elementsMargin: 6,
     itemsAmount: 100,
     disableEasing: false,
-    type: [null, ...LIST_TYPE.reverse()],
+    type: [null, ...LIST_TYPE],
     onPress: action('Button pressed'),
     globalScroll: true,
     shiftScroll: false,

--- a/src/stories/scrollBox/ScrollBoxSprite.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxSprite.stories.ts
@@ -15,7 +15,7 @@ const args = {
     elementsMargin: 6,
     itemsAmount: 100,
     disableEasing: false,
-    type: [null, ...LIST_TYPE],
+    type: [null, ...LIST_TYPE.reverse()],
     onPress: action('Button pressed'),
     globalScroll: true,
     shiftScroll: false,

--- a/src/stories/switcher/Switcher.stories.ts
+++ b/src/stories/switcher/Switcher.stories.ts
@@ -1,7 +1,7 @@
 import { PixiStory, StoryFn } from '@pixi/storybook-renderer';
 import { Switcher } from '../../Switcher';
 import { centerElement } from '../../utils/helpers/resize';
-import { BUTTON_EVENTS } from '../../utils/HelpTypes';
+import { BUTTON_EVENTS, ButtonEvent } from '../../utils/HelpTypes';
 import { argTypes, getDefaultArgs } from '../utils/argTypes';
 import { preload } from '../utils/loader';
 import { action } from '@storybook/addon-actions';
@@ -15,9 +15,9 @@ const args = {
 
 export const Sprites: StoryFn<
     typeof args & {
-    triggerEvent1: string;
-    triggerEvent2: string;
-    triggerEvent3: string;
+    triggerEvent1: ButtonEvent;
+    triggerEvent2: ButtonEvent;
+    triggerEvent3: ButtonEvent;
 }
 > = ({ action, triggerEvent1, triggerEvent2, triggerEvent3 }, context) =>
     new PixiStory<typeof args>({

--- a/src/utils/HelpTypes.ts
+++ b/src/utils/HelpTypes.ts
@@ -10,7 +10,7 @@ export interface DragObject extends Container
     dragGlobalStart: Point;
 }
 
-export const BUTTON_EVENTS = ['onPress', 'onDown', 'onUp', 'onHover', 'onOut', 'onUpOut'];
+export const BUTTON_EVENTS = ['onPress', 'onDown', 'onUp', 'onHover', 'onOut', 'onUpOut'] as const;
 
 export type ButtonEvent = (typeof BUTTON_EVENTS)[number];
 
@@ -25,5 +25,5 @@ export type Padding =
         bottom?: number;
     };
 
-export const LIST_TYPE = ['vertical', 'horizontal', 'bidirectional'];
+export const LIST_TYPE = ['vertical', 'horizontal', 'bidirectional'] as const;
 


### PR DESCRIPTION
- This will make bi-directional scrolling an opt-in rather than enabled by default, ie. allowing the items to flow bi-directionally but only scrollable vertically when type is not specified.