### PR TITLE
fix: [ScrollBox] arrange children when force resizing.

### DIFF
--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -562,14 +562,17 @@ export class ScrollBox extends Container
         if (this._dimensionChanged)
         {
             this.list.arrangeChildren();
-
             // Since the scrolling adjustment can happen due to the resize,
             // we shouldn't update the visible items immediately.
             this.stopRenderHiddenItems();
 
             this._dimensionChanged = false;
         }
-        else this.updateVisibleItems();
+        else
+        {
+            if (force) this.list.arrangeChildren();
+            this.updateVisibleItems();
+        }
 
         this.lastScrollX = null;
         this.lastScrollY = null;


### PR DESCRIPTION
Now, after resizing an item, `scrollBox.resize(true)` to rearrange the items.