### PR TITLE
extended Input keysToSkip array

### DIFF
--- a/src/Input.ts
+++ b/src/Input.ts
@@ -159,7 +159,7 @@ export class Input extends Container
     {
         const key = e.key;
 
-        const keysToSkip = ['Shift', 'Control', 'Alt', 'Meta', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'];
+        const keysToSkip = ['Shift', 'Control', 'Alt', 'Meta', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown', 'CapsLock', 'AltGraph', 'Tab', 'ContextMenu', 'F1', 'F2', 'F3', 'F4', 'F5', 'F6', 'F7', 'F8', 'F9', 'F10', 'F11', 'F12', 'ScrollLock', 'Pause', 'Insert', 'Delete', 'Home', 'End', 'PageUp', 'PageDown', 'NumLock', 'Dead'];
 
         if (keysToSkip.includes(key)) return;
 


### PR DESCRIPTION
Some keys that should be skipped are not skipped, leading to unintended behavior (duplicate letters). Extending the keysToSkip array helps to prevent this problem. I added all of the problematic keys that I could find on my (Estonian) keyboard to the array.