### PR TITLE
Enable strictNullChecks and fix all "npm run types" errors

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     },
     "lint-staged": {
         "*.{ts,js,mjs}": [
-            "npm run lint:fix --"
+            "npm run lint:fix --",
+            "npm run types"
         ]
     },
     "extensionConfig": {

--- a/src/Button.ts
+++ b/src/Button.ts
@@ -21,7 +21,7 @@ import { ButtonEvents } from './ButtonEvents';
 export class Button extends ButtonEvents
 {
     /** Container, given as a constructor parameter that is a button view. */
-    protected _view: Container;
+    protected _view: Container | undefined;
 
     /**
      * Turns a given container-based view into a button by adding all button events.
@@ -43,14 +43,14 @@ export class Button extends ButtonEvents
     {
         const wasItInitiated = !!this._view;
 
-        if (wasItInitiated) this.disconnectEvents(this._view);
+        if (wasItInitiated && this._view) this.disconnectEvents(this._view);
 
         this._view = view;
         this.connectEvents(this._view);
     }
 
-    /** Get button view, thar all the interaction events are applied to. */
-    get view(): Container
+    /** Get button view, that all the interaction events are applied to. */
+    get view(): Container | undefined
     {
         return this._view;
     }
@@ -80,7 +80,7 @@ export class Button extends ButtonEvents
     /** Getter that returns button state. */
     get enabled(): boolean
     {
-        return this.view.eventMode === 'static';
+        return this.view?.eventMode === 'static';
     }
 }
 

--- a/src/ButtonEvents.ts
+++ b/src/ButtonEvents.ts
@@ -4,8 +4,8 @@ import { Signal } from 'typed-signals';
 /** Events controller used for {@link Button}. */
 export class ButtonEvents
 {
-    protected _isMouseIn: boolean;
-    protected _isDown: boolean;
+    protected _isMouseIn = false;
+    protected _isDown = false;
 
     /** Event that is fired when the button is down. */
     onDown: Signal<(btn?: this, e?: FederatedPointerEvent) => void>;

--- a/src/CheckBox.ts
+++ b/src/CheckBox.ts
@@ -88,14 +88,20 @@ export class CheckBox extends Switcher
             if (this.labelText)
             {
                 cleanup(this.labelText);
+                this.labelText = undefined;
             }
-
-            this.labelText = undefined;
 
             return;
         }
 
-        this.labelText ? (this.labelText.text = text) : this.addLabel(text);
+        if (this.labelText)
+        {
+            this.labelText.text = text;
+        }
+        else
+        {
+            this.addLabel(text);
+        }
 
         this.alignText();
     }
@@ -121,31 +127,25 @@ export class CheckBox extends Switcher
 
         this.views = [uncheckedView, checkedView];
 
+        // Set initial view visibility based on checked state
         if (wasChecked)
         {
             checkedView.visible = true;
+            uncheckedView.visible = false;
             this.active = 1;
         }
         else
         {
             uncheckedView.visible = true;
+            checkedView.visible = false;
+            this.active = 0;
         }
 
-        if (this.labelText)
+        // Update text style if text exists and style has text configuration
+        if (this.labelText && style.text)
         {
-            checkedView.visible = true;
-            this.active = 1;
-
-            if (style.text)
-            {
-                this.labelText.style = style.text;
-            }
-
+            this.labelText.style = style.text;
             this.alignText();
-        }
-        else
-        {
-            uncheckedView.visible = true;
         }
     }
 

--- a/src/CheckBox.ts
+++ b/src/CheckBox.ts
@@ -35,12 +35,12 @@ export type CheckBoxOptions = {
 export class CheckBox extends Switcher
 {
     //* Text label */
-    labelText!: PixiText;
+    labelText: PixiText | undefined;
 
     /** Signal emitted when checkbox state changes. */
     onCheck: Signal<(state: boolean) => void>;
 
-    protected _style: CheckBoxStyle;
+    protected _style: CheckBoxStyle | undefined;
     protected _textClass: PixiTextClass;
 
     constructor(options: CheckBoxOptions)
@@ -48,11 +48,11 @@ export class CheckBox extends Switcher
         super();
 
         this._textClass = options.TextClass ?? Text;
-        this.text = options.text;
+        this.text = options.text ?? '';
 
         this.style = options.style;
 
-        this.checked = options.checked;
+        this.checked = options.checked ?? false;
 
         this.triggerEvents = ['onPress'];
 
@@ -85,7 +85,9 @@ export class CheckBox extends Switcher
     {
         if (!text)
         {
-            cleanup(this.labelText);
+            if (this.labelText) {
+                cleanup(this.labelText);
+            }
 
             this.labelText = undefined;
 
@@ -147,7 +149,7 @@ export class CheckBox extends Switcher
     }
 
     /** Getter, which returns a checkbox style settings. */
-    get style(): CheckBoxStyle
+    get style(): CheckBoxStyle | undefined
     {
         return this._style;
     }

--- a/src/CheckBox.ts
+++ b/src/CheckBox.ts
@@ -85,7 +85,8 @@ export class CheckBox extends Switcher
     {
         if (!text)
         {
-            if (this.labelText) {
+            if (this.labelText)
+            {
                 cleanup(this.labelText);
             }
 

--- a/src/CircularProgressBar.ts
+++ b/src/CircularProgressBar.ts
@@ -29,7 +29,7 @@ export type MaskedProgressBarOptions = {
 export class CircularProgressBar extends Container
 {
     private _progress = 0;
-    private options: MaskedProgressBarOptions;
+    private options: MaskedProgressBarOptions | undefined;
 
     private bgCircle = new Graphics();
     private fillCircle = new Graphics();
@@ -61,7 +61,7 @@ export class CircularProgressBar extends Container
 
         this.addBackground();
 
-        if (options.value)
+        if (options?.value)
         {
             this.progress = options.value;
         }
@@ -69,11 +69,13 @@ export class CircularProgressBar extends Container
 
     private addBackground()
     {
+        if (!this.options) return;
+        
         const { backgroundColor, lineWidth, radius, backgroundAlpha } = this.options;
 
         let alpha = 1;
 
-        if (backgroundAlpha > 0)
+        if (backgroundAlpha && backgroundAlpha > 0)
         {
             alpha = backgroundAlpha;
         }

--- a/src/CircularProgressBar.ts
+++ b/src/CircularProgressBar.ts
@@ -39,7 +39,7 @@ export class CircularProgressBar extends Container
 
     /**
      * Creates a Circular ProgressBar.
-     * @param { number } options - Options object to use.
+     * @param { MaskedProgressBarOptions } options - Options object to use.
      * @param { ColorSource } options.backgroundColor - Background color.
      * @param { ColorSource } options.fillColor - Fill color.
      * @param { number } options.lineWidth - Line width.
@@ -71,16 +71,16 @@ export class CircularProgressBar extends Container
     {
         const { backgroundColor, lineWidth = 5, radius = 50, backgroundAlpha } = this.options;
 
+        // Set alpha based on background configuration
         let alpha = 1;
-
-        if (backgroundAlpha && backgroundAlpha > 0)
-        {
-            alpha = backgroundAlpha;
-        }
 
         if (backgroundColor === undefined)
         {
             alpha = 0.000001;
+        }
+        else if (backgroundAlpha !== undefined && backgroundAlpha > 0)
+        {
+            alpha = backgroundAlpha;
         }
 
         this.bgCircle.circle(0, 0, radius).stroke({

--- a/src/CircularProgressBar.ts
+++ b/src/CircularProgressBar.ts
@@ -2,9 +2,9 @@ import { ColorSource, Container, DEG_TO_RAD, Graphics, LineCap } from 'pixi.js';
 
 export type MaskedProgressBarOptions = {
     backgroundColor?: ColorSource;
-    fillColor: ColorSource;
-    lineWidth: number;
-    radius: number;
+    fillColor?: ColorSource;
+    lineWidth?: number;
+    radius?: number;
     value?: number;
     backgroundAlpha?: number;
     fillAlpha?: number;
@@ -29,7 +29,7 @@ export type MaskedProgressBarOptions = {
 export class CircularProgressBar extends Container
 {
     private _progress = 0;
-    private options: MaskedProgressBarOptions | undefined;
+    private options: MaskedProgressBarOptions = {};
 
     private bgCircle = new Graphics();
     private fillCircle = new Graphics();
@@ -69,9 +69,7 @@ export class CircularProgressBar extends Container
 
     private addBackground()
     {
-        if (!this.options) return;
-        
-        const { backgroundColor, lineWidth, radius, backgroundAlpha } = this.options;
+        const { backgroundColor, lineWidth = 5, radius = 50, backgroundAlpha } = this.options;
 
         let alpha = 1;
 
@@ -110,9 +108,7 @@ export class CircularProgressBar extends Container
 
         this._progress = value;
 
-        if (!this.options) return;
-        
-        const { lineWidth, radius, fillColor, fillAlpha, cap } = this.options;
+        const { lineWidth = 5, radius = 50, fillColor = 0xffffff, fillAlpha, cap } = this.options;
 
         if (value === 0 && fillAlpha === 0)
         {

--- a/src/CircularProgressBar.ts
+++ b/src/CircularProgressBar.ts
@@ -110,6 +110,8 @@ export class CircularProgressBar extends Container
 
         this._progress = value;
 
+        if (!this.options) return;
+        
         const { lineWidth, radius, fillColor, fillAlpha, cap } = this.options;
 
         if (value === 0 && fillAlpha === 0)

--- a/src/CircularProgressBar.ts
+++ b/src/CircularProgressBar.ts
@@ -53,7 +53,7 @@ export class CircularProgressBar extends Container
     {
         super();
 
-        this.options = options;
+        this.options = options ?? {};
 
         this.addChild(this.innerView);
 

--- a/src/DoubleSlider.ts
+++ b/src/DoubleSlider.ts
@@ -150,8 +150,8 @@ export class DoubleSlider extends SliderBase
         const obj = event.currentTarget as DragObject;
         const { x } = obj.parent.worldTransform.applyInverse(event.global);
 
-        const slider1Dist = Math.abs(x - this._slider1.x - this._slider1.width);
-        const slider2Dist = Math.abs(x - this._slider2.x);
+        const slider1Dist = this._slider1 ? Math.abs(x - this._slider1.x - this._slider1.width) : Infinity;
+        const slider2Dist = this._slider2 ? Math.abs(x - this._slider2.x) : Infinity;
 
         if (!this.activeValue)
         {
@@ -208,7 +208,7 @@ export class DoubleSlider extends SliderBase
     }
 
     /** Get Slider1 instance. */
-    override get slider1(): Container
+    override get slider1(): Container | undefined
     {
         return this._slider1;
     }
@@ -224,7 +224,7 @@ export class DoubleSlider extends SliderBase
     }
 
     /** Get Slider2 instance. */
-    override get slider2(): Container
+    override get slider2(): Container | undefined
     {
         return this._slider2;
     }

--- a/src/DoubleSlider.ts
+++ b/src/DoubleSlider.ts
@@ -62,6 +62,7 @@ export class DoubleSlider extends SliderBase
         const min = this.sliderOptions.min ?? this.min;
         const max = this.sliderOptions.max ?? this.max;
 
+        // Initialize missing values with safe defaults
         if (!this.sliderOptions.value1)
         {
             this.sliderOptions.value1 = min;
@@ -75,11 +76,13 @@ export class DoubleSlider extends SliderBase
         let value1 = this.sliderOptions.value1 ?? min;
         let value2 = this.sliderOptions.value2 ?? max;
 
+        // Ensure value2 is not less than value1
         if (value2 < value1)
         {
             value2 = value1;
         }
 
+        // Clamp values to min/max bounds
         if (value1 < min)
         {
             value1 = min;

--- a/src/DoubleSlider.ts
+++ b/src/DoubleSlider.ts
@@ -23,7 +23,7 @@ export class DoubleSlider extends SliderBase
 {
     protected sliderOptions: DoubleSliderOptions;
 
-    protected activeValue: 'value1' | 'value2';
+    protected activeValue: 'value1' | 'value2' | undefined;
 
     /** Signal that fires when value have changed. */
     onChange: Signal<(value1: number, value2: number) => void> = new Signal();
@@ -47,8 +47,8 @@ export class DoubleSlider extends SliderBase
 
         this.updateProgress(value1, value2);
 
-        this.value2 = value2;
-        this.value1 = value1;
+        this.value2 = value2 ?? 0;
+        this.value1 = value1 ?? 0;
     }
 
     protected updateProgress(value1 = this.value1, value2 = this.value2)
@@ -69,22 +69,25 @@ export class DoubleSlider extends SliderBase
             this.sliderOptions.value2 = this.sliderOptions.max;
         }
 
-        if (this.sliderOptions.value2 < this.sliderOptions.value1)
+        const value1 = this.sliderOptions.value1 ?? this.min;
+        const value2 = this.sliderOptions.value2 ?? this.sliderOptions.max;
+
+        if (value2 < value1)
         {
-            this.sliderOptions.value2 = this.sliderOptions.value1;
+            this.sliderOptions.value2 = value1;
         }
 
-        if (this.sliderOptions.value1 < this.sliderOptions.min)
+        if (value1 < this.sliderOptions.min)
         {
             this.sliderOptions.value1 = this.sliderOptions.min;
         }
 
-        if (this.sliderOptions.value1 > this.sliderOptions.max)
+        if (value1 > this.sliderOptions.max)
         {
             this.sliderOptions.value1 = this.sliderOptions.max;
         }
 
-        if (this.sliderOptions.value2 > this.sliderOptions.max)
+        if (value2 > this.sliderOptions.max)
         {
             this.sliderOptions.value2 = this.sliderOptions.max;
         }
@@ -180,7 +183,7 @@ export class DoubleSlider extends SliderBase
     {
         super.endUpdate();
 
-        this.activeValue = null;
+        this.activeValue = undefined;
     }
 
     protected override change()

--- a/src/DoubleSlider.ts
+++ b/src/DoubleSlider.ts
@@ -231,10 +231,12 @@ export class DoubleSlider extends SliderBase
 
     protected updateSlider1()
     {
+        if (!this._slider1) return;
+
         this.updateProgress(this.value1, this.value2);
 
-        this._slider1.x = ((this.bg?.width / 100) * this.progressStart) - (this._slider1.width / 2);
-        this._slider1.y = this.bg?.height / 2;
+        this._slider1.x = ((this.bg?.width ?? 0) / 100 * this.progressStart) - (this._slider1.width / 2);
+        this._slider1.y = (this.bg?.height ?? 0) / 2;
 
         if (this._slider2 && this._slider1.x > this._slider2.x)
         {
@@ -255,12 +257,14 @@ export class DoubleSlider extends SliderBase
 
     protected updateSlider2()
     {
+        if (!this._slider2) return;
+
         this.updateProgress(this.value1, this.value2);
 
-        this._slider2.x = ((this.bg?.width / 100) * this.progress) - (this._slider2.width / 2);
-        this._slider2.y = this.bg?.height / 2;
+        this._slider2.x = ((this.bg?.width ?? 0) / 100 * this.progress) - (this._slider2.width / 2);
+        this._slider2.y = (this.bg?.height ?? 0) / 2;
 
-        if (this._slider2.x < this._slider1.x)
+        if (this._slider1 && this._slider2.x < this._slider1.x)
         {
             this._slider2.x = this._slider1.x;
         }

--- a/src/DoubleSlider.ts
+++ b/src/DoubleSlider.ts
@@ -59,38 +59,44 @@ export class DoubleSlider extends SliderBase
 
     protected validateValues()
     {
+        const min = this.sliderOptions.min ?? this.min;
+        const max = this.sliderOptions.max ?? this.max;
+
         if (!this.sliderOptions.value1)
         {
-            this.sliderOptions.value1 = this.min;
+            this.sliderOptions.value1 = min;
         }
 
         if (!this.sliderOptions.value2)
         {
-            this.sliderOptions.value2 = this.sliderOptions.max;
+            this.sliderOptions.value2 = max;
         }
 
-        const value1 = this.sliderOptions.value1 ?? this.min;
-        const value2 = this.sliderOptions.value2 ?? this.sliderOptions.max;
+        let value1 = this.sliderOptions.value1 ?? min;
+        let value2 = this.sliderOptions.value2 ?? max;
 
         if (value2 < value1)
         {
-            this.sliderOptions.value2 = value1;
+            value2 = value1;
         }
 
-        if (value1 < this.sliderOptions.min)
+        if (value1 < min)
         {
-            this.sliderOptions.value1 = this.sliderOptions.min;
+            value1 = min;
         }
 
-        if (value1 > this.sliderOptions.max)
+        if (value1 > max)
         {
-            this.sliderOptions.value1 = this.sliderOptions.max;
+            value1 = max;
         }
 
-        if (value2 > this.sliderOptions.max)
+        if (value2 > max)
         {
-            this.sliderOptions.value2 = this.sliderOptions.max;
+            value2 = max;
         }
+
+        this.sliderOptions.value1 = value1;
+        this.sliderOptions.value2 = value2;
     }
 
     /** Returns left value. */
@@ -235,7 +241,7 @@ export class DoubleSlider extends SliderBase
             this._slider1.x = this._slider2.x;
         }
 
-        if (this.sliderOptions?.showValue)
+        if (this.sliderOptions?.showValue && this.value1Text && this._slider1)
         {
             this.value1Text.text = `${Math.round(this.value1)}`;
 
@@ -259,7 +265,7 @@ export class DoubleSlider extends SliderBase
             this._slider2.x = this._slider1.x;
         }
 
-        if (this.sliderOptions?.showValue)
+        if (this.sliderOptions?.showValue && this.value2Text && this._slider2)
         {
             this.value2Text.text = `${Math.round(this.value2)}`;
 

--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -133,7 +133,7 @@ export class FancyButton extends ButtonContainer
     protected defaultDuration = 100;
 
     /** FancyButton options. */
-    protected readonly options?: ButtonOptions;
+    protected readonly options: ButtonOptions;
 
     /** Padding of the button text view. If button text does not fit active view + padding it will scale down to fit. */
     _padding: number = 0;
@@ -263,7 +263,10 @@ export class FancyButton extends ButtonContainer
         this.pressedView = pressedView ?? null;
         this.disabledView = disabledView ?? null;
         this.text = text ?? '';
-        this.iconView = icon;
+        if (icon !== undefined) 
+        {
+            this.iconView = icon;
+        }
 
         this.initStateControl();
     }
@@ -441,44 +444,56 @@ export class FancyButton extends ButtonContainer
         if (!this.text) return;
 
         const activeView = this.getStateView(this.state);
-        const { x: anchorX, y: anchorY } = this._defaultTextAnchor;
+        const anchorX = this._defaultTextAnchor.x ?? 0.5;
+        const anchorY = this._defaultTextAnchor.y ?? 0.5;
 
         if (activeView)
         {
-            if (!this.options.ignoreRefitting)
+            if (!this.options?.ignoreRefitting && this._views.textView)
             {
                 this._views.textView.scale.set(this._defaultTextScale.x, this._defaultTextScale.y);
             }
 
             if (this.contentFittingMode === 'default')
             {
-                fitToView(activeView, this._views.textView, this.padding, false);
+                if (this._views.textView) 
+                {
+                    fitToView(activeView, this._views.textView, this.padding, false);
+                }
             }
 
             if (this.contentFittingMode === 'fill')
             {
-                // reset to base dimensions for calculations
-                this._views.textView.scale.set(1);
+                if (this._views.textView) 
+                {
+                    // reset to base dimensions for calculations
+                    this._views.textView.scale.set(1);
 
-                const availableWidth = activeView.width - (this.padding * 2);
-                const availableHeight = activeView.height - (this.padding * 2);
-                const targetScaleX = availableWidth / this._views.textView.width;
-                const targetScaleY = availableHeight / this._views.textView.height;
-                const scale = Math.min(targetScaleX, targetScaleY);
+                    const availableWidth = activeView.width - (this.padding * 2);
+                    const availableHeight = activeView.height - (this.padding * 2);
+                    const targetScaleX = availableWidth / this._views.textView.width;
+                    const targetScaleY = availableHeight / this._views.textView.height;
+                    const scale = Math.min(targetScaleX, targetScaleY);
 
-                this._views.textView.scale.set(
-                    scale * this._defaultTextScale.x,
-                    scale * this._defaultTextScale.y,
-                );
+                    this._views.textView.scale.set(
+                        scale * (this._defaultTextScale.x ?? 1),
+                        scale * (this._defaultTextScale.y ?? 1),
+                    );
+                }
             }
 
-            this._views.textView.x = activeView.x + (activeView.width / 2);
-            this._views.textView.y = activeView.y + (activeView.height / 2);
+            if (this._views.textView) 
+            {
+                this._views.textView.x = activeView.x + (activeView.width / 2);
+                this._views.textView.y = activeView.y + (activeView.height / 2);
+            }
         }
 
-        this._views.textView.anchor.set(anchorX, anchorY);
-
-        this.setOffset(this._views.textView, state, this.textOffset);
+        if (this._views.textView) 
+        {
+            this._views.textView.anchor.set(anchorX, anchorY);
+            this.setOffset(this._views.textView, state, this.textOffset);
+        }
     }
 
     /**
@@ -499,7 +514,7 @@ export class FancyButton extends ButtonContainer
             return;
         }
 
-        if (!this.options.ignoreRefitting)
+        if (!this.options?.ignoreRefitting)
         {
             this._views.iconView.scale.set(this._defaultIconScale.x, this._defaultIconScale.y);
         }
@@ -521,12 +536,13 @@ export class FancyButton extends ButtonContainer
             const scale = Math.min(targetScaleX, targetScaleY);
 
             this._views.iconView.scale.set(
-                scale * this._defaultIconScale.x,
-                scale * this._defaultIconScale.y,
+                scale * (this._defaultIconScale.x ?? 1),
+                scale * (this._defaultIconScale.y ?? 1),
             );
         }
 
-        const { x: anchorX, y: anchorY } = this._defaultIconAnchor;
+        const anchorX = this._defaultIconAnchor.x ?? 0.5;
+        const anchorY = this._defaultIconAnchor.y ?? 0.5;
 
         if ('anchor' in this._views.iconView)
         {
@@ -753,7 +769,7 @@ export class FancyButton extends ButtonContainer
         if (this._views[viewType])
         {
             this.innerView.removeChild(this._views[viewType]);
-            this._views[viewType] = null;
+            this._views[viewType] = undefined;
         }
     }
 
@@ -850,16 +866,16 @@ export class FancyButton extends ButtonContainer
 
             if (defaultStateAnimation)
             {
-                this.innerView.x = defaultStateAnimation.props.x ?? this.originalInnerViewState.x;
-                this.innerView.y = defaultStateAnimation.props.y ?? this.originalInnerViewState.y;
+                this.innerView.x = defaultStateAnimation.props.x ?? this.originalInnerViewState.x ?? 0;
+                this.innerView.y = defaultStateAnimation.props.y ?? this.originalInnerViewState.y ?? 0;
                 this.innerView.width
-                    = defaultStateAnimation.props.width ?? this.originalInnerViewState.width;
+                    = defaultStateAnimation.props.width ?? this.originalInnerViewState.width ?? 0;
                 this.innerView.height
-                    = defaultStateAnimation.props.height ?? this.originalInnerViewState.height;
+                    = defaultStateAnimation.props.height ?? this.originalInnerViewState.height ?? 0;
                 this.innerView.scale.x
-                    = defaultStateAnimation.props.scale.x ?? this.originalInnerViewState.scale.x;
+                    = defaultStateAnimation.props.scale?.x ?? this.originalInnerViewState.scale?.x ?? 1;
                 this.innerView.scale.y
-                    = defaultStateAnimation.props.scale.y ?? this.originalInnerViewState.scale.y;
+                    = defaultStateAnimation.props.scale?.y ?? this.originalInnerViewState.scale?.y ?? 1;
 
                 return;
             }
@@ -871,7 +887,7 @@ export class FancyButton extends ButtonContainer
         {
             const data = stateAnimation;
 
-            this.defaultDuration = data.duration;
+            this.defaultDuration = data.duration ?? this.defaultDuration;
 
             new Tween(this.innerView).to(data.props, data.duration).start();
 

--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -128,24 +128,24 @@ export type ButtonOptions = ViewsInput & {
  */
 export class FancyButton extends ButtonContainer
 {
-    protected animations: StateAnimations;
-    protected originalInnerViewState: AnimationData;
+    protected animations: StateAnimations = {};
+    protected originalInnerViewState: AnimationData = {};
     protected defaultDuration = 100;
 
     /** FancyButton options. */
     protected readonly options?: ButtonOptions;
 
     /** Padding of the button text view. If button text does not fit active view + padding it will scale down to fit. */
-    _padding: number;
+    _padding: number = 0;
 
     /** Offset of the button state views. If state views have different sizes, this option can help adjust them. */
-    _offset: Offset & Pos;
+    _offset: Offset & Pos = {};
 
     /** Offset of the text view. Can be set to any state of the button. */
-    _textOffset: Offset;
+    _textOffset: Offset = {};
 
     /** Offset of the icon view. Can be set to any state of the button. */
-    iconOffset: Offset;
+    iconOffset: Offset = {};
 
     //* View that holds all button inner views */
     innerView = new Container();
@@ -153,7 +153,7 @@ export class FancyButton extends ButtonContainer
     protected _views: ButtonViews = {};
 
     /** State of the button. Possible valuers are: 'default', 'hover', 'pressed', 'disabled' */
-    state: State;
+    state: State = 'default';
 
     /** Anchor point of the button. */
     anchor: ObservablePoint;
@@ -241,13 +241,13 @@ export class FancyButton extends ButtonContainer
         this.anchor.set(anchorX ?? anchor ?? 0, anchorY ?? anchor ?? 0);
 
         this.padding = padding ?? 0;
-        this.offset = offset;
-        this.textOffset = textOffset;
-        this.iconOffset = iconOffset;
-        this.defaultTextScale = textScale;
-        this.defaultIconScale = iconScale;
-        this.defaultTextAnchor = textAnchor;
-        this.defaultIconAnchor = iconAnchor;
+        this.offset = offset ?? {};
+        this.textOffset = textOffset ?? {};
+        this.iconOffset = iconOffset ?? {};
+        this.defaultTextScale = textScale ?? { x: 1, y: 1 };
+        this.defaultIconScale = iconScale ?? { x: 1, y: 1 };
+        this.defaultTextAnchor = textAnchor ?? { x: 0.5, y: 0.5 };
+        this.defaultIconAnchor = iconAnchor ?? { x: 0.5, y: 0.5 };
         this.scale.set(scale ?? 1);
 
         if (animations)
@@ -258,11 +258,11 @@ export class FancyButton extends ButtonContainer
 
         this.setState('default');
 
-        this.defaultView = defaultView;
-        this.hoverView = hoverView;
-        this.pressedView = pressedView;
-        this.disabledView = disabledView;
-        this.text = text;
+        this.defaultView = defaultView ?? null;
+        this.hoverView = hoverView ?? null;
+        this.pressedView = pressedView ?? null;
+        this.disabledView = disabledView ?? null;
+        this.text = text ?? '';
         this.iconView = icon;
 
         this.initStateControl();

--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -442,6 +442,7 @@ export class FancyButton extends ButtonContainer
     protected adjustTextView(state: State)
     {
         if (!this.text) return;
+        if (!this._views.textView) return;
 
         const activeView = this.getStateView(this.state);
         const anchorX = this._defaultTextAnchor.x ?? 0.5;
@@ -449,51 +450,39 @@ export class FancyButton extends ButtonContainer
 
         if (activeView)
         {
-            if (!this.options?.ignoreRefitting && this._views.textView)
+            if (!this.options?.ignoreRefitting)
             {
                 this._views.textView.scale.set(this._defaultTextScale.x, this._defaultTextScale.y);
             }
 
             if (this.contentFittingMode === 'default')
             {
-                if (this._views.textView)
-                {
-                    fitToView(activeView, this._views.textView, this.padding, false);
-                }
+                fitToView(activeView, this._views.textView, this.padding, false);
             }
 
             if (this.contentFittingMode === 'fill')
             {
-                if (this._views.textView)
-                {
-                    // reset to base dimensions for calculations
-                    this._views.textView.scale.set(1);
+                // reset to base dimensions for calculations
+                this._views.textView.scale.set(1);
 
-                    const availableWidth = activeView.width - (this.padding * 2);
-                    const availableHeight = activeView.height - (this.padding * 2);
-                    const targetScaleX = availableWidth / this._views.textView.width;
-                    const targetScaleY = availableHeight / this._views.textView.height;
-                    const scale = Math.min(targetScaleX, targetScaleY);
+                const availableWidth = activeView.width - (this.padding * 2);
+                const availableHeight = activeView.height - (this.padding * 2);
+                const targetScaleX = availableWidth / this._views.textView.width;
+                const targetScaleY = availableHeight / this._views.textView.height;
+                const scale = Math.min(targetScaleX, targetScaleY);
 
-                    this._views.textView.scale.set(
-                        scale * (this._defaultTextScale.x ?? 1),
-                        scale * (this._defaultTextScale.y ?? 1),
-                    );
-                }
+                this._views.textView.scale.set(
+                    scale * (this._defaultTextScale.x ?? 1),
+                    scale * (this._defaultTextScale.y ?? 1),
+                );
             }
 
-            if (this._views.textView)
-            {
-                this._views.textView.x = activeView.x + (activeView.width / 2);
-                this._views.textView.y = activeView.y + (activeView.height / 2);
-            }
+            this._views.textView.x = activeView.x + (activeView.width / 2);
+            this._views.textView.y = activeView.y + (activeView.height / 2);
         }
 
-        if (this._views.textView)
-        {
-            this._views.textView.anchor.set(anchorX, anchorY);
-            this.setOffset(this._views.textView, state, this.textOffset);
-        }
+        this._views.textView.anchor.set(anchorX, anchorY);
+        this.setOffset(this._views.textView, state, this.textOffset);
     }
 
     /**

--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -258,10 +258,10 @@ export class FancyButton extends ButtonContainer
 
         this.setState('default');
 
-        this.defaultView = defaultView ?? null;
-        this.hoverView = hoverView ?? null;
-        this.pressedView = pressedView ?? null;
-        this.disabledView = disabledView ?? null;
+        this.defaultView = defaultView;
+        this.hoverView = hoverView;
+        this.pressedView = pressedView;
+        this.disabledView = disabledView;
         this.text = text ?? '';
         if (icon !== undefined) 
         {

--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -263,7 +263,7 @@ export class FancyButton extends ButtonContainer
         this.pressedView = pressedView;
         this.disabledView = disabledView;
         this.text = text ?? '';
-        if (icon !== undefined) 
+        if (icon !== undefined)
         {
             this.iconView = icon;
         }
@@ -456,7 +456,7 @@ export class FancyButton extends ButtonContainer
 
             if (this.contentFittingMode === 'default')
             {
-                if (this._views.textView) 
+                if (this._views.textView)
                 {
                     fitToView(activeView, this._views.textView, this.padding, false);
                 }
@@ -464,7 +464,7 @@ export class FancyButton extends ButtonContainer
 
             if (this.contentFittingMode === 'fill')
             {
-                if (this._views.textView) 
+                if (this._views.textView)
                 {
                     // reset to base dimensions for calculations
                     this._views.textView.scale.set(1);
@@ -482,14 +482,14 @@ export class FancyButton extends ButtonContainer
                 }
             }
 
-            if (this._views.textView) 
+            if (this._views.textView)
             {
                 this._views.textView.x = activeView.x + (activeView.width / 2);
                 this._views.textView.y = activeView.y + (activeView.height / 2);
             }
         }
 
-        if (this._views.textView) 
+        if (this._views.textView)
         {
             this._views.textView.anchor.set(anchorX, anchorY);
             this.setOffset(this._views.textView, state, this.textOffset);

--- a/src/FancyButton.ts
+++ b/src/FancyButton.ts
@@ -621,7 +621,7 @@ export class FancyButton extends ButtonContainer
      * Sets the default view of the button.
      * @param { string | Container } view - string (path to the image) or a Container-based view
      */
-    set defaultView(view: GetViewSettings | null)
+    set defaultView(view: GetViewSettings | undefined)
     {
         this.updateView('defaultView', view);
         if (this._views.disabledView && this.state !== 'default')
@@ -640,7 +640,7 @@ export class FancyButton extends ButtonContainer
      * Sets the hover view of the button.
      * @param { string | Container } view - string (path to the image) or a Container-based view
      */
-    set hoverView(view: GetViewSettings | null)
+    set hoverView(view: GetViewSettings | undefined)
     {
         this.updateView('hoverView', view);
         if (this._views.hoverView && this.state !== 'hover')
@@ -656,7 +656,7 @@ export class FancyButton extends ButtonContainer
     }
 
     /** Sets the pressed view of the button. */
-    set pressedView(view: GetViewSettings | null)
+    set pressedView(view: GetViewSettings | undefined)
     {
         this.updateView('pressedView', view);
         if (this._views.pressedView && this.state !== 'pressed')
@@ -672,7 +672,7 @@ export class FancyButton extends ButtonContainer
     }
 
     /** Sets the disabled view of the button. */
-    set disabledView(view: GetViewSettings | null)
+    set disabledView(view: GetViewSettings | undefined)
     {
         this.updateView('disabledView', view);
         if (this._views.disabledView && this.state !== 'disabled')
@@ -692,16 +692,11 @@ export class FancyButton extends ButtonContainer
      * @param { 'defaultView' | 'hoverView' | 'pressedView' | 'disabledView' } viewType - type of the view to update
      * @param { string | Texture | Container | null } view - new view
      */
-    protected updateView(viewType: ButtonViewType, view: GetViewSettings | null)
+    protected updateView(viewType: ButtonViewType, view: GetViewSettings | undefined)
     {
         if (view === undefined) return;
 
         this.removeView(viewType);
-
-        if (view === null)
-        {
-            return;
-        }
 
         if (this.options?.nineSliceSprite)
         {
@@ -804,7 +799,7 @@ export class FancyButton extends ButtonContainer
      * Sets the iconView of the button.
      * @param { string | Texture | Container } view - string (path to the image), texture instance or a Container-based view
      */
-    set iconView(view: GetViewSettings | null)
+    set iconView(view: GetViewSettings | undefined)
     {
         if (view === undefined) return;
 

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -118,6 +118,8 @@ export class Input extends Container
     {
         super();
 
+        // Establish sensible defaults for all input options
+        // to avoid null checks throughout the component
         const defaultOptions: Partial<InputOptions> = {
             bg: Texture.WHITE,
             textStyle: {

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -54,19 +54,19 @@ const SECURE_CHARACTER = '*';
 export class Input extends Container
 {
     protected _bg?: Container | NineSliceSprite | Graphics;
-    protected inputMask: Container | NineSliceSprite | Graphics;
-    protected _cursor: Sprite;
+    protected inputMask: Container | NineSliceSprite | Graphics = new Container();
+    protected _cursor: Sprite = new Sprite();
     protected _value: string = '';
-    protected _secure: boolean;
-    protected inputField: PixiText;
-    protected placeholder: PixiText;
+    protected _secure: boolean = false;
+    protected inputField: PixiText = new Text();
+    protected placeholder: PixiText = new Text();
     protected editing = false;
     protected tick = 0;
-    protected lastInputData: string;
+    protected lastInputData: string = '';
 
     protected activation = false;
     protected readonly options: InputOptions;
-    protected input: HTMLInputElement;
+    protected input: HTMLInputElement = document.createElement('input');
 
     protected handleActivationBinding = this.handleActivation.bind(this);
     protected onKeyUpBinding = this.onKeyUp.bind(this);

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -9,7 +9,6 @@ import {
     Size,
     Sprite,
     Text,
-    TextStyleOptions,
     Texture,
     Ticker,
 } from 'pixi.js';
@@ -120,12 +119,12 @@ export class Input extends Container
 
         // Establish sensible defaults for all input options
         // to avoid null checks throughout the component
-        const defaultOptions: Partial<InputOptions> = {
+        const defaultOptions: InputOptions = {
             bg: Texture.WHITE,
             textStyle: {
                 fill: 0x000000,
                 align: 'center',
-            } as TextStyleOptions,
+            },
             TextClass: Text,
             placeholder: '',
             value: '',
@@ -137,9 +136,12 @@ export class Input extends Container
             addMask: false,
         };
 
-        this.options = { ...defaultOptions, ...options } as InputOptions;
-        this.padding = this.options.padding as Padding;
-        this._secure = this.options.secure as boolean;
+        this.options = { ...defaultOptions, ...options };
+
+        const { padding = 0, secure = false } = this.options;
+
+        this.padding = padding;
+        this._secure = secure;
 
         this.cursor = 'text';
         this.interactive = true;
@@ -215,13 +217,17 @@ export class Input extends Container
 
     protected init()
     {
-        const options = this.options;
-        const textStyle = options.textStyle as TextStyleOptions;
+        const {
+            textStyle = { fill: 0x000000, align: 'center' },
+            TextClass = Text,
+            placeholder = ''
+        } = this.options;
+
         const colorSource = textStyle.fill && Color.isColorLike(textStyle.fill)
             ? textStyle.fill
             : 0x000000;
 
-        this.inputField = new (this.options.TextClass as PixiTextClass)({
+        this.inputField = new TextClass({
             text: '',
             style: textStyle,
         });
@@ -234,11 +240,11 @@ export class Input extends Container
         this._cursor.height = this.inputField.height * 0.8;
         this._cursor.alpha = 0;
 
-        this.placeholder = new (this.options.TextClass as PixiTextClass)({
-            text: this.options.placeholder as string,
+        this.placeholder = new TextClass({
+            text: placeholder,
             style: textStyle,
         });
-        this.placeholder.visible = !!(this.options.placeholder as string);
+        this.placeholder.visible = !!placeholder;
 
         this.addChild(this.inputField, this.placeholder, this._cursor);
 

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -241,7 +241,7 @@ export class Input extends Container
 
         this.addChild(this.inputField, this.placeholder, this._cursor);
 
-        this.value = this.options.value as string;
+        this.value = this.options.value ?? '';
 
         this.align();
     }

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -66,7 +66,7 @@ export class Input extends Container
 
     protected activation = false;
     protected readonly options: InputOptions;
-    protected input: HTMLInputElement = document.createElement('input');
+    protected input: HTMLInputElement | undefined;
 
     protected handleActivationBinding = this.handleActivation.bind(this);
     protected onKeyUpBinding = this.onKeyUp.bind(this);

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -54,12 +54,12 @@ const SECURE_CHARACTER = '*';
 export class Input extends Container
 {
     protected _bg?: Container | NineSliceSprite | Graphics;
-    protected inputMask: Container | NineSliceSprite | Graphics = new Container();
-    protected _cursor: Sprite = new Sprite();
+    protected inputMask: Container | NineSliceSprite | Graphics | undefined;
+    protected _cursor: Sprite | undefined;
     protected _value: string = '';
     protected _secure: boolean = false;
-    protected inputField: PixiText = new Text();
-    protected placeholder: PixiText = new Text();
+    protected inputField: PixiText | undefined;
+    protected placeholder: PixiText | undefined;
     protected editing = false;
     protected tick = 0;
     protected lastInputData: string = '';

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -119,6 +119,7 @@ export class Input extends Container
         super();
 
         const defaultOptions: Partial<InputOptions> = {
+            bg: Texture.WHITE,
             textStyle: {
                 fill: 0x000000,
                 align: 'center',
@@ -140,8 +141,6 @@ export class Input extends Container
 
         this.cursor = 'text';
         this.interactive = true;
-
-        this.bg = this.options.bg;
 
         this.on('pointertap', () =>
         {
@@ -253,22 +252,25 @@ export class Input extends Container
             this._bg.destroy();
         }
 
+        // Use Texture.WHITE as fallback if bg is undefined
+        const bgValue = bg ?? Texture.WHITE;
+
         if (this.options?.nineSliceSprite)
         {
-            if (typeof bg === 'string')
+            if (typeof bgValue === 'string')
             {
                 this._bg = new NineSliceSprite({
-                    texture: Texture.from(bg),
+                    texture: Texture.from(bgValue),
                     leftWidth: this.options.nineSliceSprite[0],
                     topHeight: this.options.nineSliceSprite[1],
                     rightWidth: this.options.nineSliceSprite[2],
                     bottomHeight: this.options.nineSliceSprite[3],
                 });
             }
-            else if (bg instanceof Texture)
+            else if (bgValue instanceof Texture)
             {
                 this._bg = new NineSliceSprite({
-                    texture: bg,
+                    texture: bgValue,
                     leftWidth: this.options.nineSliceSprite[0],
                     topHeight: this.options.nineSliceSprite[1],
                     rightWidth: this.options.nineSliceSprite[2],
@@ -284,7 +286,7 @@ export class Input extends Container
 
         if (!this._bg)
         {
-            this._bg = getView(bg);
+            this._bg = getView(bgValue);
         }
 
         this._bg.cursor = 'text';

--- a/src/Input.ts
+++ b/src/Input.ts
@@ -140,7 +140,7 @@ export class Input extends Container
 
         this.cursor = 'text';
         this.interactive = true;
-        
+
         this.bg = this.options.bg;
 
         this.on('pointertap', () =>
@@ -345,11 +345,11 @@ export class Input extends Container
 
         this.tick = 0;
         this.editing = true;
-        if (this.placeholder) 
+        if (this.placeholder)
         {
             this.placeholder.visible = false;
         }
-        if (this._cursor) 
+        if (this._cursor)
         {
             this._cursor.alpha = 1;
         }
@@ -430,13 +430,13 @@ export class Input extends Container
     {
         if (!this.editing) return;
 
-        if (this._cursor) 
+        if (this._cursor)
         {
             this._cursor.alpha = 0;
         }
         this.editing = false;
 
-        if (this.placeholder && this.value.length === 0) 
+        if (this.placeholder && this.value.length === 0)
         {
             this.placeholder.visible = true;
         }
@@ -454,7 +454,7 @@ export class Input extends Container
     {
         if (!this.editing) return;
         this.tick += dt * 0.1;
-        if (this._cursor) 
+        if (this._cursor)
         {
             this._cursor.alpha = Math.round((Math.sin(this.tick) * 0.5) + 0.5);
         }
@@ -466,7 +466,7 @@ export class Input extends Container
 
         const align = this.getAlign();
 
-        if (this.inputField) 
+        if (this.inputField)
         {
             this.inputField.anchor.set(align, 0.5);
             this.inputField.x
@@ -492,7 +492,7 @@ export class Input extends Container
     protected getAlign(): 0 | 1 | 0.5
     {
         if (!(this._bg && this.inputField)) return 0;
-        
+
         const maxWidth = this._bg.width * 0.95;
         const paddings = this.paddingLeft + this.paddingRight - 10;
         const isOverflowed = this.inputField.width + paddings > maxWidth;
@@ -517,7 +517,7 @@ export class Input extends Container
     protected getCursorPosX()
     {
         if (!this.inputField) return 0;
-        
+
         const align = this.getAlign();
 
         switch (align)
@@ -539,8 +539,8 @@ export class Input extends Container
         const textLength = text.length;
 
         this._value = text;
-        
-        if (this.inputField) 
+
+        if (this.inputField)
         {
             this.inputField.text = this.secure ? SECURE_CHARACTER.repeat(textLength) : text;
         }

--- a/src/List.ts
+++ b/src/List.ts
@@ -46,7 +46,7 @@ export class List<C extends ContainerChild = ContainerChild> extends Container<C
 
 
     /** Arrange direction. */
-    protected _type: ListType = 'vertical';
+    protected _type: ListType = 'bidirectional';
 
     /** Width of area to fit elements when arrange. (If not set parent width will be used). */
     protected _maxWidth: number = 0;
@@ -293,7 +293,7 @@ export class List<C extends ContainerChild = ContainerChild> extends Container<C
         let y = this.topPadding;
 
         const elementsMargin = this.options?.elementsMargin ?? 0;
-        let maxWidth = this.maxWidth ?? this.parent?.width;
+        let maxWidth = this.maxWidth || this.parent?.width;
 
         if (this.rightPadding)
         {

--- a/src/List.ts
+++ b/src/List.ts
@@ -293,6 +293,7 @@ export class List<C extends ContainerChild = ContainerChild> extends Container<C
         let y = this.topPadding;
 
         const elementsMargin = this.options?.elementsMargin ?? 0;
+        // Use logical OR to fallback from 0 (default) to parent width for bidirectional layout
         let maxWidth = this.maxWidth || this.parent?.width;
 
         if (this.rightPadding)

--- a/src/List.ts
+++ b/src/List.ts
@@ -44,8 +44,7 @@ export class List<C extends ContainerChild = ContainerChild> extends Container<C
 {
     protected options?: { type?: ListType } & ListOptions<C>;
 
-
-    /** Arrange direction. */
+    /** Arrange direction. Defaults to 'bidirectional' for multi-column layout when type is not specified. */
     protected _type: ListType = 'bidirectional';
 
     /** Width of area to fit elements when arrange. (If not set parent width will be used). */
@@ -82,6 +81,7 @@ export class List<C extends ContainerChild = ContainerChild> extends Container<C
     {
         this.options = options;
 
+        // Only override the default 'bidirectional' type if explicitly specified
         if (options?.type)
         {
             this.type = options.type;
@@ -293,7 +293,6 @@ export class List<C extends ContainerChild = ContainerChild> extends Container<C
         let y = this.topPadding;
 
         const elementsMargin = this.options?.elementsMargin ?? 0;
-        // Use logical OR to fallback from 0 (default) to parent width for bidirectional layout
         let maxWidth = this.maxWidth || this.parent?.width;
 
         if (this.rightPadding)

--- a/src/List.ts
+++ b/src/List.ts
@@ -44,14 +44,12 @@ export class List<C extends ContainerChild = ContainerChild> extends Container<C
 {
     protected options?: { type?: ListType } & ListOptions<C>;
 
-    /** Container, that holds all inner elements. */
-    view: Container;
 
     /** Arrange direction. */
-    protected _type: ListType;
+    protected _type: ListType = 'vertical';
 
     /** Width of area to fit elements when arrange. (If not set parent width will be used). */
-    protected _maxWidth: number;
+    protected _maxWidth: number = 0;
 
     /** Returns all arranged elements. */
     override readonly children: C[] = [];

--- a/src/MaskedFrame.ts
+++ b/src/MaskedFrame.ts
@@ -21,12 +21,12 @@ export type MaskedFrameOptions = {
 export class MaskedFrame extends Container
 {
     /** Target container. */
-    target: Container;
+    target: Container | undefined;
     border = new Graphics();
-    protected _targetMask: Container;
-    protected maskData: string | Graphics;
-    protected borderWidth: number;
-    protected borderColor: FillStyleInputs;
+    protected _targetMask: Container | undefined;
+    protected maskData: string | Graphics | undefined;
+    protected borderWidth: number = 0;
+    protected borderColor: FillStyleInputs = 0x000000;
 
     constructor(options?: MaskedFrameOptions)
     {
@@ -53,11 +53,16 @@ export class MaskedFrame extends Container
             this.removeChild(this.target);
         }
 
-        this.target = getView(target);
-        this.addChild(this.border, this.target);
+        if (target) {
+            this.target = getView(target);
+        }
+        this.addChild(this.border);
+        if (this.target) {
+            this.addChild(this.target);
+        }
 
         if (mask) this.applyMask(mask);
-        if (borderWidth) this.setBorder(borderWidth, borderColor);
+        if (borderWidth) this.setBorder(borderWidth, borderColor ?? 0x000000);
     }
 
     /**
@@ -70,7 +75,9 @@ export class MaskedFrame extends Container
 
         this._targetMask = getView(mask);
         this.addChild(this._targetMask);
-        this.target.mask = this._targetMask;
+        if (this.target) {
+            this.target.mask = this._targetMask;
+        }
     }
 
     /**

--- a/src/MaskedFrame.ts
+++ b/src/MaskedFrame.ts
@@ -92,7 +92,7 @@ export class MaskedFrame extends Container
 
         this.showBorder();
 
-        if (this.maskData)
+        if (this.maskData && this._targetMask)
         {
             const borderMask
                 = typeof this.maskData === 'string'
@@ -111,6 +111,8 @@ export class MaskedFrame extends Container
     /** Hides a border. */
     showBorder()
     {
+        if (!this.target) return;
+        
         const width = this.borderWidth * 2;
 
         this.border

--- a/src/MaskedFrame.ts
+++ b/src/MaskedFrame.ts
@@ -53,11 +53,13 @@ export class MaskedFrame extends Container
             this.removeChild(this.target);
         }
 
-        if (target) {
+        if (target)
+        {
             this.target = getView(target);
         }
         this.addChild(this.border);
-        if (this.target) {
+        if (this.target)
+        {
             this.addChild(this.target);
         }
 
@@ -75,7 +77,8 @@ export class MaskedFrame extends Container
 
         this._targetMask = getView(mask);
         this.addChild(this._targetMask);
-        if (this.target) {
+        if (this.target)
+        {
             this.target.mask = this._targetMask;
         }
     }
@@ -112,7 +115,7 @@ export class MaskedFrame extends Container
     showBorder()
     {
         if (!this.target) return;
-        
+
         const width = this.borderWidth * 2;
 
         this.border

--- a/src/ProgressBar.ts
+++ b/src/ProgressBar.ts
@@ -52,7 +52,6 @@ export class ProgressBar extends Container
     /** Container, that holds all inner views. */
     innerView: Container;
 
-
     /**
      * Creates a ProgressBar.
      * @param options - Options.

--- a/src/ProgressBar.ts
+++ b/src/ProgressBar.ts
@@ -52,8 +52,6 @@ export class ProgressBar extends Container
     /** Container, that holds all inner views. */
     innerView: Container;
 
-    /** Container, given as a constructor parameter that is a button view. */
-    protected _view: Container;
 
     /**
      * Creates a ProgressBar.
@@ -82,15 +80,24 @@ export class ProgressBar extends Container
     {
         super();
 
-        this.options = options;
+        const defaultOptions: ProgressBarOptions = {
+            bg: Texture.WHITE,
+            fill: Texture.WHITE,
+            fillPaddings: {
+                top: 0,
+                right: 0,
+                bottom: 0,
+                left: 0,
+            },
+            progress: 0,
+        };
+
+        this.options = { ...defaultOptions, ...options };
 
         this.innerView = new Container();
         this.addChild(this.innerView);
 
-        if (options?.bg && options?.fill)
-        {
-            this.init(options);
-        }
+        this.init(this.options);
     }
 
     /**
@@ -107,7 +114,7 @@ export class ProgressBar extends Container
 
         this.setFill(fill, fillPaddings);
 
-        this.progress = progress;
+        this.progress = progress ?? 0;
     }
 
     /**

--- a/src/RadioGroup.ts
+++ b/src/RadioGroup.ts
@@ -47,13 +47,13 @@ export class RadioGroup extends Container
     protected items: CheckBox[] = [];
 
     /** {@link List}, that holds and control all inned checkboxes.  */
-    innerView: List;
+    innerView: List | undefined;
 
     /** Text value of the selected item. */
-    value: string;
+    value: string = '';
 
     /** ID of the selected item. */
-    selected: number;
+    selected: number = 0;
 
     /** Fires, when new item is selected. */
     onChange: Signal<(selectedItemID: number, selectedVal: string) => void>;
@@ -64,12 +64,17 @@ export class RadioGroup extends Container
     {
         super();
 
-        if (options)
-        {
-            this.init(options);
-        }
+        const defaultOptions: RadioBoxOptions = {
+            items: [],
+            type: 'vertical',
+            elementsMargin: 0,
+            selectedItem: 0,
+        };
 
+        this.options = { ...defaultOptions, ...options };
         this.onChange = new Signal();
+
+        this.init(this.options);
     }
 
     /**
@@ -80,9 +85,8 @@ export class RadioGroup extends Container
     {
         this.options = options;
 
-        this.value = options.items[options.selectedItem || 0].labelText?.text;
-
         this.selected = options.selectedItem ?? 0; // first item by default
+        this.value = options.items[this.selected]?.labelText?.text ?? '';
 
         if (this.innerView)
         {
@@ -116,7 +120,7 @@ export class RadioGroup extends Container
 
             this.items.push(checkBox);
 
-            this.innerView.addChild(checkBox);
+            this.innerView?.addChild(checkBox);
         });
     }
 
@@ -134,7 +138,7 @@ export class RadioGroup extends Container
 
             item.onChange.disconnectAll();
 
-            this.innerView.removeChild(item);
+            this.innerView?.removeChild(item);
 
             this.items.splice(id, 1);
         });
@@ -153,10 +157,10 @@ export class RadioGroup extends Container
 
         if (this.selected !== id)
         {
-            this.onChange.emit(id, this.items[id].labelText?.text);
+            this.onChange.emit(id, this.items[id].labelText?.text ?? '');
         }
 
-        this.value = this.options.items[id].labelText?.text;
+        this.value = this.options.items[id].labelText?.text ?? '';
         this.selected = id;
     }
 }

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -511,17 +511,18 @@ export class ScrollBox extends Container
             }
 
             this.borderMask
-                .clear()
-                .roundRect(0, 0, this._width, this._height, this.options.radius | 0)
+                ?.clear()
+                .roundRect(0, 0, this._width, this._height, (this.options.radius ?? 0) | 0)
                 .fill(0xff00ff)
                 .stroke(0x0);
-            this.borderMask.eventMode = 'none';
+            
+            if (this.borderMask) this.borderMask.eventMode = 'none';
 
             const color = this.options.background;
 
             this.background
                 ?.clear()
-                .roundRect(0, 0, this._width, this._height, this.options.radius | 0)
+                .roundRect(0, 0, this._width, this._height, (this.options.radius ?? 0) | 0)
                 .fill({
                     color: color ?? 0x000000,
                     alpha: color ? 1 : 0.0000001, // if color is not set, set alpha to 0 to be able to drag by click on bg
@@ -931,11 +932,18 @@ export class ScrollBox extends Container
     {
         if (item.eventMode !== 'auto')
         {
-            isMobile.any ? item.emit('pointerupoutside', null) : item.emit('mouseupoutside', null);
+            if (isMobile.any)
+            {
+                item.emit('pointerupoutside', { target: item } as FederatedPointerEvent);
+            }
+            else
+            {
+                item.emit('mouseupoutside', { target: item } as FederatedPointerEvent);
+            }
 
             this.interactiveStorage.push({
                 item,
-                eventMode: item.eventMode,
+                eventMode: item.eventMode ?? 'auto',
             });
 
             item.eventMode = 'auto';
@@ -950,12 +958,12 @@ export class ScrollBox extends Container
 
     get scrollHeight(): number
     {
-        return this.list.height;
+        return this.list?.height ?? 0;
     }
 
     get scrollWidth(): number
     {
-        return this.list.width;
+        return this.list?.width ?? 0;
     }
 
     protected get isVertical(): boolean

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -162,6 +162,15 @@ export class ScrollBox extends Container
             super.addChild(this.list);
         }
 
+        console.log('=== ScrollBox List Init Debug ===');
+        console.log('options.type:', options.type);
+        console.log('options.maxWidth:', options.maxWidth);
+        console.log('this._width:', this._width);
+        console.log('is bidirectional:', options.type === 'bidirectional');
+        const calculatedMaxWidth = options.maxWidth ?? (options.type === 'bidirectional' ? this._width : undefined);
+        console.log('calculated maxWidth for list:', calculatedMaxWidth);
+        console.log('=== End ScrollBox List Init Debug ===');
+
         this.list?.init({
             type: options.type,
             elementsMargin: options.elementsMargin,
@@ -172,7 +181,7 @@ export class ScrollBox extends Container
             bottomPadding: options.bottomPadding,
             leftPadding: options.leftPadding,
             rightPadding: options.rightPadding,
-            maxWidth: options.maxWidth ?? (options.type === 'bidirectional' ? this._width : undefined),
+            maxWidth: calculatedMaxWidth,
         });
 
         if (options.items)

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -518,7 +518,7 @@ export class ScrollBox extends Container
                 .roundRect(0, 0, this._width, this._height, (this.options.radius ?? 0) | 0)
                 .fill(0xff00ff)
                 .stroke(0x0);
-            
+
             if (this.borderMask) this.borderMask.eventMode = 'none';
 
             const color = this.options.background;

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -611,14 +611,14 @@ export class ScrollBox extends Container
 
             if (this.listWidth < this._width)
             {
-                this._trackpad.xAxis.value = 0;
+                this._trackpad && (this._trackpad.xAxis.value = 0);
             }
             else
             {
                 const min = this._width - this.listWidth;
                 const max = 0;
 
-                this._trackpad.xAxis.value = Math.min(max, Math.max(min, targetPos));
+                this._trackpad && (this._trackpad.xAxis.value = Math.min(max, Math.max(min, targetPos)));
             }
         }
 
@@ -628,28 +628,28 @@ export class ScrollBox extends Container
 
             if (this.listHeight < this._height)
             {
-                this._trackpad.yAxis.value = 0;
+                this._trackpad && (this._trackpad.yAxis.value = 0);
             }
             else
             {
                 const min = this._height - this.listHeight;
                 const max = 0;
 
-                this._trackpad.yAxis.value = Math.min(max, Math.max(min, targetPos));
+                this._trackpad && (this._trackpad.yAxis.value = Math.min(max, Math.max(min, targetPos)));
             }
         }
 
         if (this.isBidirectional && (scrollOnX || scrollOnY))
         {
-            this.onScroll?.emit({ x: this._trackpad.xAxis.value, y: this._trackpad.yAxis.value });
+            this.onScroll?.emit({ x: this._trackpad?.xAxis.value ?? 0, y: this._trackpad?.yAxis.value ?? 0 });
         }
         else if (this.isHorizontal && scrollOnX)
         {
-            this.onScroll?.emit(this._trackpad.xAxis.value);
+            this.onScroll?.emit(this._trackpad?.xAxis.value ?? 0);
         }
         else if (this.isVertical && scrollOnY)
         {
-            this.onScroll?.emit(this._trackpad.yAxis.value);
+            this.onScroll?.emit(this._trackpad?.yAxis.value ?? 0);
         }
         this.stopRenderHiddenItems();
     }

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -172,9 +172,9 @@ export class ScrollBox extends Container
             bottomPadding: options.bottomPadding,
             leftPadding: options.leftPadding,
             rightPadding: options.rightPadding,
-            // For bidirectional and default (null/undefined) types, use ScrollBox width as maxWidth
-            // to enable multi-column layout. Other types get 0 to disable width constraints.
-            maxWidth: options.maxWidth || (options.type === 'bidirectional' || !options.type ? this._width : 0),
+            // For bidirectional type (including when options.type is null/undefined since List defaults to bidirectional),
+            // use ScrollBox width as maxWidth to enable multi-column layout. Other types get 0 to disable width constraints.
+            maxWidth: options.maxWidth || (options.type !== 'horizontal' && options.type !== 'vertical' ? this._width : 0),
         });
 
         if (options.items)

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -19,8 +19,8 @@ import { Trackpad } from './utils/trackpad/Trackpad';
 import type { ListOptions, ListType } from './List';
 
 export type ScrollBoxOptions = {
-    width: number;
-    height: number;
+    width?: number;
+    height?: number;
     background?: ColorSource;
     type?: ListType;
     radius?: number;
@@ -64,10 +64,10 @@ type ProximityEventData = {
 
 export class ScrollBox extends Container
 {
-    protected background: Graphics;
-    protected borderMask: Graphics;
-    protected lastWidth: number;
-    protected lastHeight: number;
+    protected background: Graphics = new Graphics();
+    protected borderMask: Graphics = new Graphics();
+    protected lastWidth: number = 0;
+    protected lastHeight: number = 0;
     protected _width = 0;
     protected _height = 0;
     protected _dimensionChanged = false;
@@ -76,24 +76,24 @@ export class ScrollBox extends Container
      * Arrange container, that holds all inner elements.
      * Use this control inner arrange container size in case of bidirectional scroll type.
      */
-    list: List;
+    list: List = new List();
 
-    protected _trackpad: Trackpad;
+    protected _trackpad: Trackpad = new Trackpad();
     protected isDragging = 0;
     protected interactiveStorage: {
         item: Container;
         eventMode: EventMode;
     }[] = [];
     protected visibleItems: Container[] = [];
-    protected pressedChild: Container;
+    protected pressedChild: Container = new Container();
     protected ticker = Ticker.shared;
-    protected options: ScrollBoxOptions;
+    protected options: ScrollBoxOptions = {};
     protected stopRenderHiddenItemsTimeout!: NodeJS.Timeout;
     protected onMouseScrollBinding = this.onMouseScroll.bind(this);
-    protected dragStarTouchPoint: Point;
+    protected dragStarTouchPoint: Point = new Point();
     protected isOver = false;
 
-    protected proximityRange: number;
+    protected proximityRange: number = 0;
     protected proximityStatusCache: boolean[] = [];
     protected lastScrollX!: number | null;
     protected lastScrollY!: number | null;
@@ -150,8 +150,8 @@ export class ScrollBox extends Container
         this.options = options;
         this.setBackground(options.background);
 
-        this._width = options.width | this.background.width;
-        this._height = options.height | this.background.height;
+        this._width = options.width ?? this.background.width ?? 100;
+        this._height = options.height ?? this.background.height ?? 100;
 
         this.proximityRange = options.proximityRange ?? 0;
 

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -162,7 +162,7 @@ export class ScrollBox extends Container
             super.addChild(this.list);
         }
 
-        this.list.init({
+        this.list?.init({
             type: options.type,
             elementsMargin: options.elementsMargin,
             padding: options.padding,
@@ -174,7 +174,9 @@ export class ScrollBox extends Container
             rightPadding: options.rightPadding,
         });
 
-        this.addItems(options.items);
+        if (options.items) {
+            this.addItems(options.items);
+        }
 
         if (this.hasBounds)
         {
@@ -182,8 +184,10 @@ export class ScrollBox extends Container
             this.makeScrollable();
         }
 
-        this._trackpad.xAxis.value = 0;
-        this._trackpad.yAxis.value = 0;
+        if (this._trackpad) {
+            this._trackpad.xAxis.value = 0;
+            this._trackpad.yAxis.value = 0;
+        }
 
         this.options.globalScroll = options.globalScroll ?? true;
         this.options.shiftScroll = options.shiftScroll ?? false;
@@ -210,7 +214,7 @@ export class ScrollBox extends Container
     removeItems()
     {
         this.proximityStatusCache.length = 0;
-        this.list.removeChildren();
+        this.list?.removeChildren();
     }
 
     /**
@@ -234,7 +238,7 @@ export class ScrollBox extends Container
 
             child.eventMode = 'static';
 
-            this.list.addChild(child);
+            this.list?.addChild(child);
             this.proximityStatusCache.push(false);
 
             if (!this.options.disableDynamicRendering)
@@ -254,7 +258,7 @@ export class ScrollBox extends Container
      */
     removeItem(itemID: number)
     {
-        this.list.removeItem(itemID);
+        this.list?.removeItem(itemID);
         this.proximityStatusCache.splice(itemID, 1);
         this.resize();
     }
@@ -351,7 +355,7 @@ export class ScrollBox extends Container
 
             this._trackpad.pointerDown(this.dragStarTouchPoint);
 
-            const listTouchPoint = this.list.worldTransform.applyInverse(e.global);
+            const listTouchPoint = this.list?.worldTransform.applyInverse(e.global);
 
             this.visibleItems.forEach((item) =>
             {
@@ -373,7 +377,7 @@ export class ScrollBox extends Container
             this._trackpad.pointerUp();
             this.restoreItemsInteractivity();
 
-            this.pressedChild = null;
+            this.pressedChild = undefined;
 
             this.stopRenderHiddenItems();
         });
@@ -394,7 +398,7 @@ export class ScrollBox extends Container
             this._trackpad.pointerUp();
             this.restoreItemsInteractivity();
 
-            this.pressedChild = null;
+            this.pressedChild = undefined;
 
             this.stopRenderHiddenItems();
         });
@@ -437,7 +441,7 @@ export class ScrollBox extends Container
             if (this.pressedChild)
             {
                 this.revertClick(this.pressedChild);
-                this.pressedChild = null;
+                this.pressedChild = undefined;
             }
 
             if (this.isBidirectional)
@@ -460,12 +464,12 @@ export class ScrollBox extends Container
 
     protected get listHeight(): number
     {
-        return this.list.height + this.list.topPadding + this.list.bottomPadding;
+        return (this.list?.height ?? 0) + (this.list?.topPadding ?? 0) + (this.list?.bottomPadding ?? 0);
     }
 
     protected get listWidth(): number
     {
-        return this.list.width + this.list.leftPadding + this.list.rightPadding;
+        return (this.list?.width ?? 0) + (this.list?.leftPadding ?? 0) + (this.list?.rightPadding ?? 0);
     }
 
     /**
@@ -534,15 +538,15 @@ export class ScrollBox extends Container
         {
             const maxWidth
                 = this.borderMask.width
-                - this.list.width
-                - this.list.leftPadding
-                - this.list.rightPadding;
+                - (this.list?.width ?? 0)
+                - (this.list?.leftPadding ?? 0)
+                - (this.list?.rightPadding ?? 0);
 
             const maxHeight
                 = this.borderMask.height
-                - this.list.height
-                - this.list.topPadding
-                - this.list.bottomPadding;
+                - (this.list?.height ?? 0)
+                - (this.list?.topPadding ?? 0)
+                - (this.list?.bottomPadding ?? 0);
 
             if (this.isBidirectional)
             {
@@ -561,7 +565,7 @@ export class ScrollBox extends Container
 
         if (this._dimensionChanged)
         {
-            this.list.arrangeChildren();
+            this.list?.arrangeChildren();
             // Since the scrolling adjustment can happen due to the resize,
             // we shouldn't update the visible items immediately.
             this.stopRenderHiddenItems();
@@ -570,12 +574,12 @@ export class ScrollBox extends Container
         }
         else
         {
-            if (force) this.list.arrangeChildren();
+            if (force) this.list?.arrangeChildren();
             this.updateVisibleItems();
         }
 
-        this.lastScrollX = null;
-        this.lastScrollY = null;
+        this.lastScrollX = undefined;
+        this.lastScrollY = undefined;
     }
 
     protected onMouseScroll(event: WheelEvent): void
@@ -593,7 +597,7 @@ export class ScrollBox extends Container
         if ((this.isHorizontal || this.isBidirectional) && scrollOnX)
         {
             const delta = shiftScroll || this.isBidirectional ? event.deltaX : event.deltaY;
-            const targetPos = this.list.x - delta;
+            const targetPos = (this.list?.x ?? 0) - delta;
 
             if (this.listWidth < this._width)
             {
@@ -610,7 +614,7 @@ export class ScrollBox extends Container
 
         if ((this.isVertical || this.isBidirectional) && scrollOnY)
         {
-            const targetPos = this.list.y - event.deltaY;
+            const targetPos = (this.list?.y ?? 0) - event.deltaY;
 
             if (this.listHeight < this._height)
             {
@@ -649,7 +653,7 @@ export class ScrollBox extends Container
         }
         else
         {
-            this.scrollTo(this.list.children.length - 1);
+            this.scrollTo((this.list?.children.length ?? 1) - 1);
         }
     }
 
@@ -658,8 +662,10 @@ export class ScrollBox extends Container
     {
         this.renderAllItems();
 
-        this._trackpad.xAxis.value = 0;
-        this._trackpad.yAxis.value = 0;
+        if (this._trackpad) {
+            this._trackpad.xAxis.value = 0;
+            this._trackpad.yAxis.value = 0;
+        }
 
         this.stopRenderHiddenItems();
     }
@@ -667,7 +673,7 @@ export class ScrollBox extends Container
     protected renderAllItems()
     {
         clearTimeout(this.stopRenderHiddenItemsTimeout);
-        this.stopRenderHiddenItemsTimeout = null;
+        this.stopRenderHiddenItemsTimeout = undefined;
 
         if (this.options.disableDynamicRendering)
         {
@@ -690,7 +696,7 @@ export class ScrollBox extends Container
         if (this.stopRenderHiddenItemsTimeout)
         {
             clearTimeout(this.stopRenderHiddenItemsTimeout);
-            this.stopRenderHiddenItemsTimeout = null;
+            this.stopRenderHiddenItemsTimeout = undefined;
         }
 
         this.stopRenderHiddenItemsTimeout = setTimeout(() => this.updateVisibleItems(), 2000);
@@ -718,7 +724,7 @@ export class ScrollBox extends Container
             return;
         }
 
-        const target = this.list.children[elementID];
+        const target = this.list?.children[elementID];
 
         if (!target)
         {

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -88,7 +88,7 @@ export class ScrollBox extends Container
     protected pressedChild: Container | undefined;
     protected ticker = Ticker.shared;
     protected options: ScrollBoxOptions = {};
-    protected stopRenderHiddenItemsTimeout!: NodeJS.Timeout;
+    protected stopRenderHiddenItemsTimeout: NodeJS.Timeout | undefined;
     protected onMouseScrollBinding = this.onMouseScroll.bind(this);
     protected dragStarTouchPoint: Point | undefined;
     protected isOver = false;
@@ -384,7 +384,7 @@ export class ScrollBox extends Container
         this.on('pointerup', () =>
         {
             this.isDragging = 0;
-            this._trackpad.pointerUp();
+            this._trackpad?.pointerUp();
             this.restoreItemsInteractivity();
 
             this.pressedChild = undefined;
@@ -405,7 +405,7 @@ export class ScrollBox extends Container
         this.on('pointerupoutside', () =>
         {
             this.isDragging = 0;
-            this._trackpad.pointerUp();
+            this._trackpad?.pointerUp();
             this.restoreItemsInteractivity();
 
             this.pressedChild = undefined;
@@ -446,7 +446,7 @@ export class ScrollBox extends Container
 
             if (this.dragStarTouchPoint && this.isDragging !== 2) return;
 
-            this._trackpad.pointerMove(touchPoint);
+            this._trackpad?.pointerMove(touchPoint);
 
             if (this.pressedChild)
             {
@@ -544,7 +544,7 @@ export class ScrollBox extends Container
             this.lastHeight = this.listHeight;
         }
 
-        if (this._trackpad)
+        if (this._trackpad && this.borderMask)
         {
             const maxWidth
                 = this.borderMask.width

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -150,8 +150,8 @@ export class ScrollBox extends Container
         this.options = options;
         this.setBackground(options.background);
 
-        this._width = options.width ?? this.background.width ?? 100;
-        this._height = options.height ?? this.background.height ?? 100;
+        this._width = options.width ?? this.background?.width ?? 100;
+        this._height = options.height ?? this.background?.height ?? 100;
 
         this.proximityRange = options.proximityRange ?? 0;
 

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -172,9 +172,11 @@ export class ScrollBox extends Container
             bottomPadding: options.bottomPadding,
             leftPadding: options.leftPadding,
             rightPadding: options.rightPadding,
+            maxWidth: options.maxWidth ?? (options.type === 'bidirectional' ? this._width : undefined),
         });
 
-        if (options.items) {
+        if (options.items)
+        {
             this.addItems(options.items);
         }
 
@@ -184,7 +186,8 @@ export class ScrollBox extends Container
             this.makeScrollable();
         }
 
-        if (this._trackpad) {
+        if (this._trackpad)
+        {
             this._trackpad.xAxis.value = 0;
             this._trackpad.yAxis.value = 0;
         }
@@ -355,7 +358,8 @@ export class ScrollBox extends Container
             this.isDragging = 1;
             this.dragStarTouchPoint = this.worldTransform.applyInverse(e.global);
 
-            if (this._trackpad) {
+            if (this._trackpad)
+            {
                 this._trackpad.pointerDown(this.dragStarTouchPoint);
             }
 
@@ -666,7 +670,8 @@ export class ScrollBox extends Container
     {
         this.renderAllItems();
 
-        if (this._trackpad) {
+        if (this._trackpad)
+        {
             this._trackpad.xAxis.value = 0;
             this._trackpad.yAxis.value = 0;
         }

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -273,6 +273,8 @@ export class ScrollBox extends Container
         let isVisible = false;
         const list = this.list;
 
+        if (!list) return false;
+
         if (this.isVertical || this.isBidirectional)
         {
             const posY = item.y + list.y;
@@ -353,7 +355,9 @@ export class ScrollBox extends Container
             this.isDragging = 1;
             this.dragStarTouchPoint = this.worldTransform.applyInverse(e.global);
 
-            this._trackpad.pointerDown(this.dragStarTouchPoint);
+            if (this._trackpad) {
+                this._trackpad.pointerDown(this.dragStarTouchPoint);
+            }
 
             const listTouchPoint = this.list?.worldTransform.applyInverse(e.global);
 

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -95,8 +95,8 @@ export class ScrollBox extends Container
 
     protected proximityRange: number = 0;
     protected proximityStatusCache: boolean[] = [];
-    protected lastScrollX!: number | null;
-    protected lastScrollY!: number | null;
+    protected lastScrollX: number | undefined;
+    protected lastScrollY: number | undefined;
     protected proximityCheckFrameCounter = 0;
     public onProximityChange = new Signal<(data: ProximityEventData) => void>();
     public onScroll: Signal<(value: number | PointData) => void> = new Signal();

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -162,15 +162,6 @@ export class ScrollBox extends Container
             super.addChild(this.list);
         }
 
-        console.log('=== ScrollBox List Init Debug ===');
-        console.log('options.type:', options.type);
-        console.log('options.maxWidth:', options.maxWidth);
-        console.log('this._width:', this._width);
-        console.log('is bidirectional:', options.type === 'bidirectional');
-        const calculatedMaxWidth = options.maxWidth ?? (options.type === 'bidirectional' ? this._width : undefined);
-        console.log('calculated maxWidth for list:', calculatedMaxWidth);
-        console.log('=== End ScrollBox List Init Debug ===');
-
         this.list?.init({
             type: options.type,
             elementsMargin: options.elementsMargin,
@@ -181,7 +172,9 @@ export class ScrollBox extends Container
             bottomPadding: options.bottomPadding,
             leftPadding: options.leftPadding,
             rightPadding: options.rightPadding,
-            maxWidth: calculatedMaxWidth,
+            // For bidirectional and default (null/undefined) types, use ScrollBox width as maxWidth
+            // to enable multi-column layout. Other types get 0 to disable width constraints.
+            maxWidth: options.maxWidth || (options.type === 'bidirectional' || !options.type ? this._width : 0),
         });
 
         if (options.items)

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -90,7 +90,7 @@ export class ScrollBox extends Container
     protected options: ScrollBoxOptions = {};
     protected stopRenderHiddenItemsTimeout: NodeJS.Timeout | undefined;
     protected onMouseScrollBinding = this.onMouseScroll.bind(this);
-    protected dragStarTouchPoint: Point | undefined;
+    protected dragStarTouchPoint: PointData | undefined;
     protected isOver = false;
 
     protected proximityRange: number = 0;
@@ -360,25 +360,28 @@ export class ScrollBox extends Container
             this.isDragging = 1;
             this.dragStarTouchPoint = this.worldTransform.applyInverse(e.global);
 
-            if (this._trackpad)
+            if (this._trackpad && this.dragStarTouchPoint)
             {
-                this._trackpad.pointerDown(this.dragStarTouchPoint);
+                this._trackpad.pointerDown(new Point(this.dragStarTouchPoint.x, this.dragStarTouchPoint.y));
             }
 
             const listTouchPoint = this.list?.worldTransform.applyInverse(e.global);
 
-            this.visibleItems.forEach((item) =>
+            if (listTouchPoint)
             {
-                if (
-                    item.x < listTouchPoint.x
-                    && item.x + item.width > listTouchPoint.x
-                    && item.y < listTouchPoint.y
-                    && item.y + item.height > listTouchPoint.y
-                )
+                this.visibleItems.forEach((item) =>
                 {
-                    this.pressedChild = item;
-                }
-            });
+                    if (
+                        item.x < listTouchPoint.x
+                        && item.x + item.width > listTouchPoint.x
+                        && item.y < listTouchPoint.y
+                        && item.y + item.height > listTouchPoint.y
+                    )
+                    {
+                        this.pressedChild = item;
+                    }
+                });
+            }
         });
 
         this.on('pointerup', () =>
@@ -446,7 +449,7 @@ export class ScrollBox extends Container
 
             if (this.dragStarTouchPoint && this.isDragging !== 2) return;
 
-            this._trackpad?.pointerMove(touchPoint);
+            this._trackpad?.pointerMove(new Point(touchPoint.x, touchPoint.y));
 
             if (this.pressedChild)
             {

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -64,8 +64,8 @@ type ProximityEventData = {
 
 export class ScrollBox extends Container
 {
-    protected background: Graphics = new Graphics();
-    protected borderMask: Graphics = new Graphics();
+    protected background: Graphics | undefined;
+    protected borderMask: Graphics | undefined;
     protected lastWidth: number = 0;
     protected lastHeight: number = 0;
     protected _width = 0;
@@ -76,21 +76,21 @@ export class ScrollBox extends Container
      * Arrange container, that holds all inner elements.
      * Use this control inner arrange container size in case of bidirectional scroll type.
      */
-    list: List = new List();
+    list: List | undefined;
 
-    protected _trackpad: Trackpad = new Trackpad();
+    protected _trackpad: Trackpad | undefined;
     protected isDragging = 0;
     protected interactiveStorage: {
         item: Container;
         eventMode: EventMode;
     }[] = [];
     protected visibleItems: Container[] = [];
-    protected pressedChild: Container = new Container();
+    protected pressedChild: Container | undefined;
     protected ticker = Ticker.shared;
     protected options: ScrollBoxOptions = {};
     protected stopRenderHiddenItemsTimeout!: NodeJS.Timeout;
     protected onMouseScrollBinding = this.onMouseScroll.bind(this);
-    protected dragStarTouchPoint: Point = new Point();
+    protected dragStarTouchPoint: Point | undefined;
     protected isOver = false;
 
     protected proximityRange: number = 0;

--- a/src/ScrollBox.ts
+++ b/src/ScrollBox.ts
@@ -284,7 +284,7 @@ export class ScrollBox extends Container
         {
             const posY = item.y + list.y;
 
-            if (posY + item.height >= -padding && posY <= this.options.height + padding)
+            if (posY + item.height >= -padding && posY <= (this.options.height ?? this._height) + padding)
             {
                 isVisible = true;
             }
@@ -294,7 +294,7 @@ export class ScrollBox extends Container
         {
             const posX = item.x + list.x;
 
-            if (posX + item.width >= -padding && posX <= this.options.width + padding)
+            if (posX + item.width >= -padding && posX <= (this.options.width ?? this._width) + padding)
             {
                 isVisible = true;
             }
@@ -520,7 +520,7 @@ export class ScrollBox extends Container
             const color = this.options.background;
 
             this.background
-                .clear()
+                ?.clear()
                 .roundRect(0, 0, this._width, this._height, this.options.radius | 0)
                 .fill({
                     color: color ?? 0x000000,
@@ -730,12 +730,12 @@ export class ScrollBox extends Container
      */
     scrollTo(elementID: number)
     {
-        if (!this.interactive)
+        if (!this.interactive || !this._trackpad || !this.list)
         {
             return;
         }
 
-        const target = this.list?.children[elementID];
+        const target = this.list.children[elementID];
 
         if (!target)
         {
@@ -831,30 +831,30 @@ export class ScrollBox extends Container
     /** Gets the current raw scroll position on the x-axis (Negated Value). */
     get scrollX(): number
     {
-        return this._trackpad.xAxis.value;
+        return this._trackpad?.xAxis.value ?? 0;
     }
 
     /** Sets the current raw scroll position on the x-axis (Negated Value). */
     set scrollX(value: number)
     {
-        this._trackpad.xAxis.value = value;
+        if (this._trackpad) this._trackpad.xAxis.value = value;
     }
 
     /** Gets the current raw scroll position on the y-axis (Negated Value). */
     get scrollY(): number
     {
-        return this._trackpad.yAxis.value;
+        return this._trackpad?.yAxis.value ?? 0;
     }
 
     /** Sets the current raw scroll position on the y-axis (Negated Value). */
     set scrollY(value: number)
     {
-        this._trackpad.yAxis.value = value;
+        if (this._trackpad) this._trackpad.yAxis.value = value;
     }
 
     protected update()
     {
-        if (!this.list) return;
+        if (!this.list || !this._trackpad) return;
 
         this._trackpad.update();
 
@@ -911,8 +911,8 @@ export class ScrollBox extends Container
 
         document.removeEventListener('wheel', this.onMouseScrollBinding, true);
 
-        this.background.destroy();
-        this.list.destroy();
+        this.background?.destroy();
+        this.list?.destroy();
 
         super.destroy(options);
     }

--- a/src/Select.ts
+++ b/src/Select.ts
@@ -75,10 +75,10 @@ export class Select extends Container
     protected openButton!: FancyButton;
     protected closeButton!: FancyButton;
     protected openView!: Container;
-    protected scrollBox: ScrollBox;
+    protected scrollBox: ScrollBox | undefined;
 
     /** Selected value ID. */
-    value: number;
+    value: number = -1;
 
     /** Fires when selected value is changed. */
     onSelect: Signal<(value: number, text: string) => void>;

--- a/src/Select.ts
+++ b/src/Select.ts
@@ -249,7 +249,7 @@ export class Select extends Container
                 this.close();
             });
 
-            this.scrollBox.addItem(button);
+            this.scrollBox?.addItem(button);
         });
     }
 
@@ -259,6 +259,8 @@ export class Select extends Container
      */
     removeItem(itemID: number)
     {
+        if (!this.scrollBox) return;
+
         this.scrollBox.removeItem(itemID);
     }
 

--- a/src/Select.ts
+++ b/src/Select.ts
@@ -149,7 +149,7 @@ export class Select extends Container
                 style: textStyle,
             });
 
-            this.openButton.textOffset = selectedTextOffset;
+            this.openButton.textOffset = selectedTextOffset ?? {};
         }
 
         // openView
@@ -187,7 +187,7 @@ export class Select extends Container
                 style: textStyle,
             });
 
-            this.openButton.textOffset = selectedTextOffset;
+            this.openButton.textOffset = selectedTextOffset ?? {};
         }
 
         // ScrollBox
@@ -236,16 +236,16 @@ export class Select extends Container
 
             if (id === selected)
             {
-                this.openButton.text = text;
-                this.closeButton.text = text;
+                this.openButton.text = text ?? '';
+                this.closeButton.text = text ?? '';
             }
 
             button.onPress.connect(() =>
             {
                 this.value = id;
-                this.onSelect.emit(id, text);
-                this.openButton.text = text;
-                this.closeButton.text = text;
+                this.onSelect.emit(id, text ?? '');
+                this.openButton.text = text ?? '';
+                this.closeButton.text = text ?? '';
                 this.close();
             });
 

--- a/src/Slider.ts
+++ b/src/Slider.ts
@@ -137,12 +137,14 @@ export class Slider extends SliderBase
 
     protected updateSlider()
     {
+        if (!this._slider1) return;
+
         this.progress = (((this.value ?? this.min) - this.min) / (this.max - this.min)) * 100;
 
-        this._slider1.x = ((this.bg?.width / 100) * this.progress) - (this._slider1.width / 2);
-        this._slider1.y = this.bg?.height / 2;
+        this._slider1.x = ((this.bg?.width ?? 0) / 100 * this.progress) - (this._slider1.width / 2);
+        this._slider1.y = (this.bg?.height ?? 0) / 2;
 
-        if (this.sliderOptions?.showValue)
+        if (this.sliderOptions?.showValue && this.value1Text)
         {
             this.value1Text.text = `${Math.round(this.value)}`;
 

--- a/src/SliderBase.ts
+++ b/src/SliderBase.ts
@@ -107,7 +107,7 @@ export class SliderBase extends ProgressBar
     }
 
     /** Get Slider1 instance. */
-    get slider1(): Container
+    get slider1(): Container | undefined
     {
         return this._slider1;
     }
@@ -142,7 +142,7 @@ export class SliderBase extends ProgressBar
     }
 
     /** Get Slider2 instance. */
-    get slider2(): Container
+    get slider2(): Container | undefined
     {
         return this._slider2;
     }

--- a/src/SliderBase.ts
+++ b/src/SliderBase.ts
@@ -28,14 +28,14 @@ export type DoubleSliderOptions = BaseSliderOptions & {
 /** Hepper class, used as a base for single or double slider creation. */
 export class SliderBase extends ProgressBar
 {
-    protected _slider1: Container;
-    protected _slider2: Container;
+    protected _slider1: Container | undefined;
+    protected _slider2: Container | undefined;
 
     protected value1Text?: PixiText;
     protected value2Text?: PixiText;
 
-    protected _value1: number;
-    protected _value2: number;
+    protected _value1: number = 0;
+    protected _value2: number = 0;
 
     protected dragging = 0;
 

--- a/src/SliderBase.ts
+++ b/src/SliderBase.ts
@@ -60,8 +60,12 @@ export class SliderBase extends ProgressBar
 
         this.settings = options;
 
-        this.slider1 = options.slider1;
-        this.slider2 = options.slider2;
+        if (options.slider1) {
+            this.slider1 = options.slider1;
+        }
+        if (options.slider2) {
+            this.slider2 = options.slider2;
+        }
 
         this.min = options.min ?? 0;
         this.max = options.max ?? 100;
@@ -87,8 +91,8 @@ export class SliderBase extends ProgressBar
 
         if (this._slider1)
         {
-            this.slider1.removeAllListeners();
-            this.slider1.destroy();
+            this._slider1.removeAllListeners();
+            this._slider1.destroy();
         }
 
         this._slider1 = this.createSlider(value);
@@ -122,8 +126,8 @@ export class SliderBase extends ProgressBar
 
         if (this._slider2)
         {
-            this.slider2.removeAllListeners();
-            this.slider2.destroy();
+            this._slider2.removeAllListeners();
+            this._slider2.destroy();
         }
 
         this._slider2 = this.createSlider(value);
@@ -236,8 +240,8 @@ export class SliderBase extends ProgressBar
             this.change();
         }
 
-        this.startUpdateValue1 = null;
-        this.startUpdateValue2 = null;
+        this.startUpdateValue1 = 0;
+        this.startUpdateValue2 = 0;
     }
 
     protected onClick()
@@ -254,7 +258,7 @@ export class SliderBase extends ProgressBar
 
         if (x !== this.startX)
         {
-            this.startX = null;
+            this.startX = 0;
         }
     }
 

--- a/src/SliderBase.ts
+++ b/src/SliderBase.ts
@@ -60,10 +60,12 @@ export class SliderBase extends ProgressBar
 
         this.settings = options;
 
-        if (options.slider1) {
+        if (options.slider1)
+        {
             this.slider1 = options.slider1;
         }
-        if (options.slider2) {
+        if (options.slider2)
+        {
             this.slider2 = options.slider2;
         }
 

--- a/src/Switcher.ts
+++ b/src/Switcher.ts
@@ -26,7 +26,7 @@ export class Switcher extends Container
     innerView: Container;
 
     /** The id of the visible(active) view. */
-    protected _active: number;
+    protected _active: number = 0;
 
     /** Fired when active view changes. */
     onChange: Signal<(state: number | boolean) => void>;

--- a/src/Switcher.ts
+++ b/src/Switcher.ts
@@ -186,7 +186,7 @@ export class Switcher extends Container
             throw new Error(`View with id ${id} does not exist.`);
         }
 
-        this._active = id !== undefined ? id : this.nextActive;
+        this._active = id === undefined ? this.nextActive : id;
 
         if (this._active === undefined)
         {

--- a/src/Switcher.ts
+++ b/src/Switcher.ts
@@ -26,7 +26,7 @@ export class Switcher extends Container
     innerView: Container;
 
     /** The id of the visible(active) view. */
-    protected _active: number = 0;
+    protected _active: number | undefined = 0;
 
     /** Fired when active view changes. */
     onChange: Signal<(state: number | boolean) => void>;
@@ -79,7 +79,7 @@ export class Switcher extends Container
     /** Returns the active view. */
     get activeView(): Container | undefined
     {
-        if (this.views && this.views[this.active])
+        if (this.views && this.active !== undefined && this.views[this.active])
         {
             return this.views[this.active] as Container;
         }
@@ -162,7 +162,7 @@ export class Switcher extends Container
 
         if (exID !== this.active)
         {
-            const res = this.views.length > 2 ? this.active : this.active === 1;
+            const res = this.views.length > 2 ? (this.active ?? 0) : (this.active === 1);
 
             this.onChange.emit(res);
         }
@@ -193,13 +193,15 @@ export class Switcher extends Container
             return;
         }
 
-        this.views[this.active].visible = true;
+        this.views[this._active].visible = true;
     }
 
     /** Returns the id of the next view in order. Or undefined, if order is empty. */
     protected get nextActive(): number | undefined
     {
         if (this.views.length === 0) return undefined;
+
+        if (this.active === undefined) return 0;
 
         return this.active < this.views.length - 1 ? this.active + 1 : 0;
     }
@@ -211,7 +213,7 @@ export class Switcher extends Container
     }
 
     /** Gets the id of the visible(active) view. */
-    get active(): number
+    get active(): number | undefined
     {
         return this._active;
     }

--- a/src/Switcher.ts
+++ b/src/Switcher.ts
@@ -26,7 +26,7 @@ export class Switcher extends Container
     innerView: Container;
 
     /** The id of the visible(active) view. */
-    protected _active: number | undefined = 0;
+    protected _active: number | undefined;
 
     /** Fired when active view changes. */
     onChange: Signal<(state: number | boolean) => void>;
@@ -51,7 +51,7 @@ export class Switcher extends Container
 
         if (views) this.views = views;
         if (triggerEvents) this.triggerEvents = triggerEvents;
-        if (activeViewID && this.views.length > 0) this.active = activeViewID;
+        if (activeViewID !== undefined && this.views.length > 0) this.active = activeViewID;
 
         this.setInteractionEvents();
     }

--- a/src/stories/button/ButtonSprite.stories.ts
+++ b/src/stories/button/ButtonSprite.stories.ts
@@ -17,7 +17,7 @@ const args = {
 export class SpriteButton extends Button
 {
     private buttonView = new Container();
-    private textView: Text;
+    private textView: Text | undefined;
     private buttonBg = new Sprite();
     private action: (event: string) => void;
 

--- a/src/stories/button/ButtonSprite.stories.ts
+++ b/src/stories/button/ButtonSprite.stories.ts
@@ -109,7 +109,10 @@ export const UseSprite: StoryFn<typeof args> = (params, context) =>
         {
             const buttonView = new SpriteButton(params);
 
-            view.addChild(buttonView.view);
+            if (buttonView.view)
+            {
+                view.addChild(buttonView.view);
+            }
 
             centerView(view);
         },

--- a/src/stories/list/ListSprite.stories.ts
+++ b/src/stories/list/ListSprite.stories.ts
@@ -56,7 +56,7 @@ export const UseSprite: StoryFn<typeof args & { type: ListType }> = (
 
                 view.addChild(window);
 
-                const items: Container[] = createItems(itemsAmount, getColor(fontColor), onPress);
+                const items: Container[] = createItems(itemsAmount, getColor(fontColor) ?? 0x000000, onPress);
 
                 // Component usage !!!
                 const list = new List({

--- a/src/stories/radio/RadioGraphics.stories.ts
+++ b/src/stories/radio/RadioGraphics.stories.ts
@@ -105,6 +105,7 @@ function drawRadio({ color, fillColor, width, height, radius, padding }: Graphic
     if (isCircle)
     {
         const w = width ?? 0;
+
         graphics.circle(w / 2, w / 2, w / 2);
     }
     else
@@ -125,6 +126,7 @@ function drawRadio({ color, fillColor, width, height, radius, padding }: Graphic
         else
         {
             const p = padding ?? 0;
+
             graphics.roundRect(p, p, (width ?? 0) - (p * 2), (height ?? 0) - (p * 2), radius ?? 0);
         }
 

--- a/src/stories/radio/RadioGraphics.stories.ts
+++ b/src/stories/radio/RadioGraphics.stories.ts
@@ -88,7 +88,10 @@ export const UseGraphics: StoryFn<typeof args> = (
                 onChange({ id: selectedItemID, val: selectedVal }),
             );
 
-            view.addChild(radioGroup.innerView);
+            if (radioGroup.innerView)
+            {
+                view.addChild(radioGroup.innerView);
+            }
         },
         resize: (view) => centerElement(view),
     });
@@ -97,7 +100,7 @@ function drawRadio({ color, fillColor, width, height, radius, padding }: Graphic
 {
     const graphics = new Graphics();
 
-    const isCircle = width === height && radius >= width / 2;
+    const isCircle = width === height && (radius ?? 0) >= (width ?? 0) / 2;
 
     if (isCircle)
     {

--- a/src/stories/radio/RadioGraphics.stories.ts
+++ b/src/stories/radio/RadioGraphics.stories.ts
@@ -104,26 +104,28 @@ function drawRadio({ color, fillColor, width, height, radius, padding }: Graphic
 
     if (isCircle)
     {
-        graphics.circle(width / 2, width / 2, width / 2);
+        const w = width ?? 0;
+        graphics.circle(w / 2, w / 2, w / 2);
     }
     else
     {
-        graphics.roundRect(0, 0, width, height, radius);
+        graphics.roundRect(0, 0, width ?? 0, height ?? 0, radius ?? 0);
     }
 
     graphics.fill(color);
 
     if (fillColor !== undefined)
     {
-        const center = width / 2;
+        const center = (width ?? 0) / 2;
 
         if (isCircle)
         {
-            graphics.circle(center, center, center - padding);
+            graphics.circle(center, center, center - (padding ?? 0));
         }
         else
         {
-            graphics.roundRect(padding, padding, width - (padding * 2), height - (padding * 2), radius);
+            const p = padding ?? 0;
+            graphics.roundRect(p, p, (width ?? 0) - (p * 2), (height ?? 0) - (p * 2), radius ?? 0);
         }
 
         graphics.fill(fillColor);

--- a/src/stories/radio/RadioSprite.stories.ts
+++ b/src/stories/radio/RadioSprite.stories.ts
@@ -61,7 +61,10 @@ export const UseSprite: StoryFn<typeof args> = ({ amount, text, textColor, onCha
                     onChange({ id: selectedItemID, val: selectedVal }),
                 );
 
-                list.addChild(radioGroup.innerView);
+                if (radioGroup.innerView)
+                {
+                    list.addChild(radioGroup.innerView);
+                }
 
                 centerElement(list);
             });

--- a/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxGraphics.stories.ts
@@ -96,7 +96,7 @@ export const UseGraphics: StoryFn<typeof args & { type: ListType }> = (
                 shiftScroll,
             });
 
-            if (type === 'bidirectional')
+            if (type === 'bidirectional' && scrollBox.list)
             {
                 scrollBox.list.maxWidth = innerListWidth;
             }

--- a/src/stories/scrollBox/ScrollBoxSprite.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxSprite.stories.ts
@@ -76,7 +76,7 @@ export const UseSprite: StoryFn<typeof args & { type: ListType }> = (
                     shiftScroll,
                 });
 
-                if (type === 'bidirectional')
+                if (type === 'bidirectional' && scrollBox.list)
                 {
                     scrollBox.list.width = window.width - 40;
                     scrollBox.list.height = window.height - 60;

--- a/src/stories/scrollBox/ScrollBoxSprite.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxSprite.stories.ts
@@ -61,13 +61,25 @@ export const UseSprite: StoryFn<typeof args & { type: ListType }> = (
 
                 view.addChild(window);
 
+                console.log('=== ScrollBoxSprite Debug Info ===');
+                console.log('windowBg dimensions:', { width: windowBg.width, height: windowBg.height });
+                console.log('window dimensions:', { width: window.width, height: window.height });
+
                 const items: Container[] = createItems(itemsAmount, fontColor, onPress);
+                console.log('Created items count:', items.length);
+                console.log('First item dimensions:', items[0] ? { width: items[0].width, height: items[0].height } : 'No items');
 
                 // Component usage !!!
+                const scrollBoxWidth = window.width - 80;
+                const scrollBoxHeight = window.height - 90;
+                console.log('Calculated scrollBox dimensions:', { width: scrollBoxWidth, height: scrollBoxHeight });
+                console.log('elementsMargin:', elementsMargin);
+                console.log('type:', type);
+
                 const scrollBox = new ScrollBox({
                     elementsMargin,
-                    width: window.width - 80,
-                    height: window.height - 90,
+                    width: scrollBoxWidth,
+                    height: scrollBoxHeight,
                     vertPadding: 18,
                     radius: 5,
                     disableEasing,
@@ -76,16 +88,33 @@ export const UseSprite: StoryFn<typeof args & { type: ListType }> = (
                     shiftScroll,
                 });
 
+                console.log('ScrollBox created with dimensions:', { width: scrollBox.width, height: scrollBox.height });
+                console.log('ScrollBox list exists:', !!scrollBox.list);
+                if (scrollBox.list)
+                {
+                    console.log('ScrollBox list dimensions before adding items:', { width: scrollBox.list.width, height: scrollBox.list.height });
+                }
+
                 if (type === 'bidirectional' && scrollBox.list)
                 {
                     scrollBox.list.width = window.width - 40;
                     scrollBox.list.height = window.height - 60;
+                    console.log('Updated bidirectional list dimensions:', { width: scrollBox.list.width, height: scrollBox.list.height });
                 }
 
                 scrollBox.addItems(items);
 
+                if (scrollBox.list)
+                {
+                    console.log('ScrollBox list dimensions after adding items:', { width: scrollBox.list.width, height: scrollBox.list.height });
+                    console.log('ScrollBox list children count:', scrollBox.list.children.length);
+                }
+
                 scrollBox.x = (window.width / 2) - (scrollBox.width / 2);
                 scrollBox.y = (window.height / 2) - (scrollBox.height / 2) + 18;
+
+                console.log('ScrollBox final position:', { x: scrollBox.x, y: scrollBox.y });
+                console.log('=== End Debug Info ===');
 
                 window.addChild(scrollBox);
 

--- a/src/stories/scrollBox/ScrollBoxSprite.stories.ts
+++ b/src/stories/scrollBox/ScrollBoxSprite.stories.ts
@@ -61,25 +61,13 @@ export const UseSprite: StoryFn<typeof args & { type: ListType }> = (
 
                 view.addChild(window);
 
-                console.log('=== ScrollBoxSprite Debug Info ===');
-                console.log('windowBg dimensions:', { width: windowBg.width, height: windowBg.height });
-                console.log('window dimensions:', { width: window.width, height: window.height });
-
                 const items: Container[] = createItems(itemsAmount, fontColor, onPress);
-                console.log('Created items count:', items.length);
-                console.log('First item dimensions:', items[0] ? { width: items[0].width, height: items[0].height } : 'No items');
 
                 // Component usage !!!
-                const scrollBoxWidth = window.width - 80;
-                const scrollBoxHeight = window.height - 90;
-                console.log('Calculated scrollBox dimensions:', { width: scrollBoxWidth, height: scrollBoxHeight });
-                console.log('elementsMargin:', elementsMargin);
-                console.log('type:', type);
-
                 const scrollBox = new ScrollBox({
                     elementsMargin,
-                    width: scrollBoxWidth,
-                    height: scrollBoxHeight,
+                    width: window.width - 80,
+                    height: window.height - 90,
                     vertPadding: 18,
                     radius: 5,
                     disableEasing,
@@ -88,33 +76,16 @@ export const UseSprite: StoryFn<typeof args & { type: ListType }> = (
                     shiftScroll,
                 });
 
-                console.log('ScrollBox created with dimensions:', { width: scrollBox.width, height: scrollBox.height });
-                console.log('ScrollBox list exists:', !!scrollBox.list);
-                if (scrollBox.list)
-                {
-                    console.log('ScrollBox list dimensions before adding items:', { width: scrollBox.list.width, height: scrollBox.list.height });
-                }
-
                 if (type === 'bidirectional' && scrollBox.list)
                 {
                     scrollBox.list.width = window.width - 40;
                     scrollBox.list.height = window.height - 60;
-                    console.log('Updated bidirectional list dimensions:', { width: scrollBox.list.width, height: scrollBox.list.height });
                 }
 
                 scrollBox.addItems(items);
 
-                if (scrollBox.list)
-                {
-                    console.log('ScrollBox list dimensions after adding items:', { width: scrollBox.list.width, height: scrollBox.list.height });
-                    console.log('ScrollBox list children count:', scrollBox.list.children.length);
-                }
-
                 scrollBox.x = (window.width / 2) - (scrollBox.width / 2);
                 scrollBox.y = (window.height / 2) - (scrollBox.height / 2) + 18;
-
-                console.log('ScrollBox final position:', { x: scrollBox.x, y: scrollBox.y });
-                console.log('=== End Debug Info ===');
 
                 window.addChild(scrollBox);
 

--- a/src/stories/utils/color.ts
+++ b/src/stories/utils/color.ts
@@ -1,7 +1,7 @@
 // eslint-disable-next-line no-restricted-imports
 import { Color } from 'pixi.js';
 
-export function getColor(color: number | string): number
+export function getColor(color: number | string): number | undefined
 {
     if (color === 'transparent')
     {

--- a/src/utils/helpers/cleanup.ts
+++ b/src/utils/helpers/cleanup.ts
@@ -10,5 +10,4 @@ export function cleanup(element: Container)
     }
 
     element.destroy();
-    element = null;
 }

--- a/src/utils/helpers/resize.ts
+++ b/src/utils/helpers/resize.ts
@@ -3,7 +3,7 @@ import { Container } from 'pixi.js';
 export function centerElement(view: Container, horPos?: number, verPos?: number)
 {
     const canvas = document.getElementById('storybook-root');
-    
+
     if (!canvas) return;
 
     if (view.width > 0)

--- a/src/utils/helpers/resize.ts
+++ b/src/utils/helpers/resize.ts
@@ -3,6 +3,8 @@ import { Container } from 'pixi.js';
 export function centerElement(view: Container, horPos?: number, verPos?: number)
 {
     const canvas = document.getElementById('storybook-root');
+    
+    if (!canvas) return;
 
     if (view.width > 0)
     {
@@ -48,6 +50,8 @@ export function centerElement(view: Container, horPos?: number, verPos?: number)
 export function centerView(view: Container)
 {
     const canvas = document.getElementById('storybook-root');
+
+    if (!canvas) return;
 
     view.x = canvas.offsetWidth / 2;
     view.y = canvas.offsetHeight / 2;

--- a/src/utils/helpers/resize.ts
+++ b/src/utils/helpers/resize.ts
@@ -4,7 +4,7 @@ export function centerElement(view: Container, horPos?: number, verPos?: number)
 {
     const canvas = document.getElementById('storybook-root');
 
-    if (!canvas) return;
+    if (!canvas || !view) return;
 
     if (view.width > 0)
     {

--- a/src/utils/trackpad/ScrollSpring.ts
+++ b/src/utils/trackpad/ScrollSpring.ts
@@ -2,13 +2,13 @@ import { Spring } from './Spring';
 
 export default class ScrollSpring
 {
-    done: boolean;
-    to: number;
+    done: boolean = false;
+    to: number = 0;
 
     protected _spring: Spring;
-    protected _pos: number;
-    protected _speed: number;
-    protected _correctSpeed: boolean;
+    protected _pos: number = 0;
+    protected _speed: number = 0;
+    protected _correctSpeed: boolean = false;
 
     constructor()
     {

--- a/src/utils/trackpad/SlidingNumber.ts
+++ b/src/utils/trackpad/SlidingNumber.ts
@@ -28,12 +28,12 @@ export class SlidingNumber
     protected _offset = 0;
     protected _prev = 0;
     protected _speed = 0;
-    protected _hasStopped: boolean;
+    protected _hasStopped: boolean = false;
 
     protected _targetSpeed = 0;
     protected _speedChecker = 0;
     protected _grab = 0;
-    protected _activeEase: ConstrainEase;
+    protected _activeEase: ConstrainEase | undefined;
 
     constructor(options: SlidingNumberOptions = {})
     {
@@ -82,7 +82,7 @@ export class SlidingNumber
 
         if (this.constrain)
         {
-            this._activeEase = null;
+            this._activeEase = undefined;
 
             if (this.position > this.min)
             {
@@ -173,7 +173,7 @@ export class SlidingNumber
             {
                 this.position = this._activeEase.to;
                 this._speed = 0;
-                this._activeEase = null;
+                this._activeEase = undefined;
             }
         }
         else

--- a/src/utils/trackpad/Spring.ts
+++ b/src/utils/trackpad/Spring.ts
@@ -12,7 +12,7 @@ export class Spring
     dx: number;
     tx: number;
 
-    protected _options: SpringOptions;
+    protected _options: Required<SpringOptions>;
 
     constructor(options: SpringOptions = {})
     {
@@ -22,10 +22,11 @@ export class Spring
         this.tx = 0;
 
         // add opts to object for shared opts.
-        this._options = options;
-        this._options.max = options.max || 160;
-        this._options.damp = options.damp || 0.8;
-        this._options.springiness = options.springiness || 0.1;
+        this._options = {
+            max: options.max ?? 160,
+            damp: options.damp ?? 0.8,
+            springiness: options.springiness ?? 0.1,
+        };
     }
 
     update(): void

--- a/src/utils/trackpad/Trackpad.ts
+++ b/src/utils/trackpad/Trackpad.ts
@@ -68,7 +68,7 @@ export class Trackpad
 
     update(): void
     {
-        if (this._dirty)
+        if (this._dirty && this._bounds && this._frame)
         {
             this._dirty = false;
 
@@ -79,7 +79,7 @@ export class Trackpad
             this.xAxis.min = this._bounds.bottom - this._frame.height;
         }
 
-        if (this._isDown)
+        if (this._isDown && this._globalPosition)
         {
             this.xAxis.hold(this._globalPosition.x);
             this.yAxis.hold(this._globalPosition.y);
@@ -93,6 +93,8 @@ export class Trackpad
 
     resize(w: number, h: number): void
     {
+        if (!this._frame) return;
+
         this._frame.x = 0;
         this._frame.width = w;
 
@@ -104,6 +106,8 @@ export class Trackpad
 
     setBounds(minX: number, maxX: number, minY: number, maxY: number): void
     {
+        if (!this._bounds) return;
+
         this._bounds.x = minX;
         this._bounds.width = maxX - minX;
         this._bounds.y = minY;

--- a/src/utils/trackpad/Trackpad.ts
+++ b/src/utils/trackpad/Trackpad.ts
@@ -19,11 +19,11 @@ export class Trackpad
     xAxis: SlidingNumber;
     yAxis: SlidingNumber;
 
-    protected _isDown: boolean;
-    protected _globalPosition: Point;
-    protected _frame: Rectangle;
-    protected _bounds: Rectangle;
-    protected _dirty: boolean;
+    protected _isDown: boolean = false;
+    protected _globalPosition: Point | undefined;
+    protected _frame: Rectangle | undefined;
+    protected _bounds: Rectangle | undefined;
+    protected _dirty: boolean = false;
     protected disableEasing = false;
 
     constructor(options: TrackpadOptions)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,6 @@
         "noUnusedLocals": true,
         "noUnusedParameters": true,
         "noImplicitReturns": true,
-        "strictNullChecks": false,
         "resolveJsonModule": true,
         "skipLibCheck": true,
         "noImplicitOverride": true


### PR DESCRIPTION
Fix https://github.com/pixijs/ui/issues/119 by the following changes:
- Enable strictNullChecks
- Fix all `npm run types` issues
- Use default values for all basic types
- Use undefined as default for all complex types
- Use *early returns* to avoid checking the mandatory properties
- Migrate events from Point to PointData
- Prevent strictNullChecks regressions by adding a local pre-commit hook