### PR TITLE
Improve safety checks in resize.ts & fit.ts

### DIFF
--- a/src/utils/helpers/fit.ts
+++ b/src/utils/helpers/fit.ts
@@ -2,12 +2,14 @@ import { Container } from 'pixi.js';
 
 export function fitToView(parent: Container, child: Container, padding = 0, uniformScaling = true)
 {
-    let scaleX = child.scale.x;
-    let scaleY = child.scale.y;
-
     if (!parent)
     {
         throw new Error('Parent is not defined');
+    }
+
+    if (!child)
+    {
+        throw new Error('Child is not defined');
     }
 
     const maxWidth = parent.width - (padding * 2);
@@ -15,6 +17,9 @@ export function fitToView(parent: Container, child: Container, padding = 0, unif
 
     const widthOverflow = maxWidth - Math.round(child.width);
     const heightOverflow = maxHeight - Math.round(child.height);
+
+    let scaleX = child.scale.x;
+    let scaleY = child.scale.y;
 
     if (widthOverflow < 0)
     {

--- a/src/utils/helpers/resize.ts
+++ b/src/utils/helpers/resize.ts
@@ -51,7 +51,7 @@ export function centerView(view: Container)
 {
     const canvas = document.getElementById('storybook-root');
 
-    if (!canvas) return;
+    if (!canvas || !view) return;
 
     view.x = canvas.offsetWidth / 2;
     view.y = canvas.offsetHeight / 2;


### PR DESCRIPTION
- Added guard condition for `undefined` view in `resize.ts` → `centerView`
- Throw error when child is `undefined` in `fit.ts` → `fitToView`
- Deferred assignment of child.scaleX/scaleY until all parameters are validated _(related to the above change)_